### PR TITLE
[Bugs] Distance and autosave

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,11 @@
     "name": "Letters Mobile",
     "slug": "letters-mobile",
     "privacy": "public",
-    "platforms": ["ios", "android", "web"],
+    "platforms": [
+      "ios",
+      "android",
+      "web"
+    ],
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./src/assets/BlueBird.png",
@@ -11,6 +15,12 @@
     "notification": {
       "icon": "./src/assets/BlueBird.png",
       "color": "#448AF3"
+    },
+    "android": {
+      "package": "com.ameelio.letters"
+    },
+    "ios": {
+      "bundleIdentifier": "com.ameelio.letters"
     }
   }
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,5 @@
+import { getZipcode } from './Common';
+
 import {
   addContact,
   updateContact,
@@ -20,6 +22,7 @@ import {
 } from './User';
 
 export {
+  getZipcode,
   addContact,
   updateContact,
   deleteContact,

--- a/src/components/Alert/Alert.react.tsx
+++ b/src/components/Alert/Alert.react.tsx
@@ -6,6 +6,7 @@ import {
   TextStyle,
   TouchableOpacity,
   Animated,
+  Platform,
 } from 'react-native';
 import { Colors, Typography } from '@styles';
 import Button from '../Button/Button.react';
@@ -60,7 +61,10 @@ class Alert extends React.Component<Record<string, unknown>, State> {
       >
         <TouchableOpacity
           style={Styles.trueBackground}
-          onPress={() => this.setCurrent(null)}
+          onPress={() => {
+            this.setCurrent(null);
+            setStatusBackground('white');
+          }}
           activeOpacity={1.0}
         >
           <View style={Styles.alertBackground}>
@@ -121,13 +125,16 @@ const alertRef = createRef<Alert>();
 const AlertInstance = (): JSX.Element => <Alert ref={alertRef} key="Alert" />;
 
 export function popupAlert(pop: AlertInfo): void {
-  setStatusBackground(GRAY_BACK);
-  if (alertRef.current)
+  setStatusBackground(Platform.OS === 'ios' ? GRAY_BACK : 'rgb(145,145,145)');
+  if (alertRef.current) {
     alertRef.current.setCurrent({
       title: pop.title,
       message: pop.message,
       buttons: pop.buttons,
     });
+  } else {
+    setStatusBackground('white');
+  }
 }
 
 export default AlertInstance;

--- a/src/components/Card/ContactSelectorCard.react.tsx
+++ b/src/components/Card/ContactSelectorCard.react.tsx
@@ -76,7 +76,7 @@ const ContactSelectorCard: React.FC<Props> = (props: Props) => {
           >
             <Emoji name="airplane" />{' '}
             {i18n.t('SingleContactScreen.lettersTraveled')}: {lettersTravelled}{' '}
-            miles
+            {i18n.t('miles')}
           </Text>
         </View>
       </View>

--- a/src/components/Card/ContactSelectorCard.react.tsx
+++ b/src/components/Card/ContactSelectorCard.react.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Text, TouchableOpacity, View, ViewStyle } from 'react-native';
 import { Colors, Typography } from '@styles';
 import Emoji from 'react-native-emoji';
 import i18n from '@i18n';
 import { ProfilePicTypes, Letter } from 'types';
 import moment from 'moment';
+import { getZipcode } from '@api/Common';
+import { haversine } from '@utils';
 import CardStyles from './Card.styles';
 import ProfilePic from '../ProfilePic/ProfilePic.react';
 
@@ -15,9 +17,28 @@ interface Props {
   letters?: Letter[];
   onPress: () => void;
   style?: ViewStyle;
+  userPostal?: string;
+  contactPostal?: string;
 }
 
 const ContactSelectorCard: React.FC<Props> = (props: Props) => {
+  const [lettersTravelled, setLettersTravelled] = useState(0);
+
+  useEffect(() => {
+    const updateLettersTravelled = async (): Promise<void> => {
+      try {
+        if (props.userPostal && props.contactPostal && props.letters) {
+          const loc1 = await getZipcode(props.userPostal);
+          const loc2 = await getZipcode(props.contactPostal);
+          setLettersTravelled(haversine(loc1, loc2) * props.letters.length);
+        }
+      } catch (err) {
+        setLettersTravelled(0);
+      }
+    };
+    updateLettersTravelled();
+  }, [props.letters, props.userPostal, props.contactPostal]);
+
   return (
     <TouchableOpacity
       style={[CardStyles.cardBase, CardStyles.shadow, props.style]}
@@ -54,7 +75,8 @@ const ContactSelectorCard: React.FC<Props> = (props: Props) => {
             ]}
           >
             <Emoji name="airplane" />{' '}
-            {i18n.t('SingleContactScreen.lettersTraveled')}:
+            {i18n.t('SingleContactScreen.lettersTraveled')}: {lettersTravelled}{' '}
+            miles
           </Text>
         </View>
       </View>

--- a/src/components/Card/ContactSelectorCard.react.tsx
+++ b/src/components/Card/ContactSelectorCard.react.tsx
@@ -76,7 +76,7 @@ const ContactSelectorCard: React.FC<Props> = (props: Props) => {
           >
             <Emoji name="airplane" />{' '}
             {i18n.t('SingleContactScreen.lettersTraveled')}: {lettersTravelled}{' '}
-            {i18n.t('miles')}
+            {i18n.t('ContactSelectorScreen.miles')}
           </Text>
         </View>
       </View>

--- a/src/components/ComposeHeader/ComposeHeader.react.tsx
+++ b/src/components/ComposeHeader/ComposeHeader.react.tsx
@@ -100,7 +100,7 @@ class ComposeHeader extends React.Component<Props, State> {
               { marginTop: 8, paddingRight: 16, color: Colors.GRAY_MEDIUM },
             ]}
           >
-            autosaved
+            {i18n.t('Compose.autosaved')}
           </Text>
           {this.state.open || this.state.animating ? (
             <TouchableOpacity

--- a/src/components/ComposeHeader/ComposeHeader.react.tsx
+++ b/src/components/ComposeHeader/ComposeHeader.react.tsx
@@ -94,6 +94,14 @@ class ComposeHeader extends React.Component<Props, State> {
           >
             {i18n.t('Compose.to')}: {this.props.recipientName}
           </Text>
+          <Text
+            style={[
+              Typography.FONT_MEDIUM_ITALIC,
+              { marginTop: 8, paddingRight: 16, color: Colors.GRAY_MEDIUM },
+            ]}
+          >
+            autosaved
+          </Text>
           {this.state.open || this.state.animating ? (
             <TouchableOpacity
               onPress={() => {

--- a/src/components/Input/Input.react.tsx
+++ b/src/components/Input/Input.react.tsx
@@ -37,7 +37,7 @@ export interface Props {
   nextInput?: RefObject<Input> | boolean;
   height: number;
   numLines: number;
-  children?: JSX.Element;
+  children?: JSX.Element | JSX.Element[];
   testId?: string;
   allowsEmoji: boolean;
   mustMatch?: string;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -316,7 +316,7 @@
     "startNewLetter": "Start new letter",
     "draftContactDeleted": "The contact that your saved draft was addressed to has been deleted. You'll have to start a new letter.",
     "notEnoughCredits": "Not enough credits",
-    "autosaved": "autosaved"
+    "autosaved": "Autosaved"
   },
   "Notifs": {
     "your": "Your",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -314,7 +314,8 @@
     "continueWriting": "Continue writing",
     "startNewLetter": "Start new letter",
     "draftContactDeleted": "The contact that your saved draft was addressed to has been deleted. You'll have to start a new letter.",
-    "notEnoughCredits": "Not enough credits"
+    "notEnoughCredits": "Not enough credits",
+    "autosaved": "autosaved"
   },
   "Notifs": {
     "your": "Your",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -66,6 +66,7 @@
   },
   "ContactSelectorScreen": {
     "yourLovedOnes": "Your loved ones",
+    "miles": "miles",
     "youDoNotHaveAnyContactsYet": "You do not have any contacts yet. Add your first contact using the button below."
   },
   "CreditsCard": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -312,7 +312,7 @@
     "continueWriting": "Continue writing",
     "startNewLetter": "Start new letter",
     "draftContactDeleted": "The contact that your saved draft was addressed to has been deleted. You'll have to start a new letter.",
-    "Autosaved": "autoguardado"
+    "autosaved": "Autoguardado"
   },
   "Notifs": {
     "your": "Tu",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -310,7 +310,8 @@
     "continueWritingAnd": "Continue writing and send that letter to your loved one",
     "continueWriting": "Continue writing",
     "startNewLetter": "Start new letter",
-    "draftContactDeleted": "The contact that your saved draft was addressed to has been deleted. You'll have to start a new letter."
+    "draftContactDeleted": "The contact that your saved draft was addressed to has been deleted. You'll have to start a new letter.",
+    "autosaved": "autoguardado"
   },
   "Notifs": {
     "your": "Tu",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -312,7 +312,7 @@
     "continueWriting": "Continue writing",
     "startNewLetter": "Start new letter",
     "draftContactDeleted": "The contact that your saved draft was addressed to has been deleted. You'll have to start a new letter.",
-    "autosaved": "autoguardado"
+    "Autosaved": "autoguardado"
   },
   "Notifs": {
     "your": "Tu",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -66,6 +66,7 @@
   },
   "ContactSelectorScreen": {
     "yourLovedOnes": "Sus seres queridos",
+    "miles": "millas",
     "youDoNotHaveAnyContactsYet": "Todavía no tienes ningún contacto. Agregar tu primer contacto utilizando el botón abajo."
   },
   "CreditsCard": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,8 @@ export interface ZipcodeInfo {
   zip: string;
   city: string;
   state: string;
+  lat?: number;
+  long?: number;
 }
 
 export interface Photo {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -219,7 +219,6 @@ export function sleep(ms: number, error = false): Promise<void> {
 }
 
 export function haversine(loc1: ZipcodeInfo, loc2: ZipcodeInfo): number {
-  return 6;
   if (!loc1.lat || !loc1.long || !loc2.lat || !loc2.long) return 0;
   const R = 6371e3;
   const φ1 = (loc1.lat * Math.PI) / 180;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,6 +4,7 @@ import PhoneNumber from 'awesome-phonenumber';
 import * as ImagePicker from 'expo-image-picker';
 import * as Permissions from 'expo-permissions';
 import { ImageInfo } from 'expo-image-picker/build/ImagePicker.types';
+import { ZipcodeInfo } from 'types';
 import {
   ABBREV_TO_STATE,
   STATE_TO_ABBREV,
@@ -215,4 +216,20 @@ export function sleep(ms: number, error = false): Promise<void> {
       else resolve();
     }, ms)
   );
+}
+
+export function haversine(loc1: ZipcodeInfo, loc2: ZipcodeInfo): number {
+  return 6;
+  if (!loc1.lat || !loc1.long || !loc2.lat || !loc2.long) return 0;
+  const R = 6371e3;
+  const φ1 = (loc1.lat * Math.PI) / 180;
+  const φ2 = (loc2.lat * Math.PI) / 180;
+  const Δφ = ((loc2.lat - loc1.lat) * Math.PI) / 180;
+  const Δλ = ((loc2.long - loc1.long) * Math.PI) / 180;
+  const a =
+    Math.sin(Δφ / 2) * Math.sin(Δφ / 2) +
+    Math.cos(φ1) * Math.cos(φ2) * Math.sin(Δλ / 2) * Math.sin(Δλ / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  const d = R * c;
+  return d * 0.000621371;
 }

--- a/src/views/Compose/ComposeLetter.react.tsx
+++ b/src/views/Compose/ComposeLetter.react.tsx
@@ -7,6 +7,7 @@ import {
   Platform,
   KeyboardAvoidingView,
   EmitterSubscription,
+  Text,
 } from 'react-native';
 import { ComposeHeader, Input, ComposeTools, PicUpload } from '@components';
 import { StackNavigationProp } from '@react-navigation/stack';
@@ -29,15 +30,6 @@ type ComposeLetterScreenNavigationProp = StackNavigationProp<
   'ComposeLetter'
 >;
 
-interface Props {
-  navigation: ComposeLetterScreenNavigationProp;
-  composing: Letter;
-  recipientName: string;
-  setContent: (content: string) => void;
-  setDraft: (value: boolean) => void;
-  setPhoto: (photo: Photo | undefined) => void;
-}
-
 interface State {
   keyboardOpacity: Animated.Value;
   wordsLeft: number;
@@ -45,6 +37,17 @@ interface State {
   photoHeight: number;
   open: boolean;
   valid: boolean;
+  saving: boolean;
+  savingOpacity: Animated.Value;
+}
+
+interface Props {
+  navigation: ComposeLetterScreenNavigationProp;
+  composing: Letter;
+  recipientName: string;
+  setContent: (content: string) => void;
+  setDraft: (value: boolean) => void;
+  setPhoto: (photo: Photo | undefined) => void;
 }
 
 class ComposeLetterScreenBase extends React.Component<Props, State> {
@@ -69,6 +72,8 @@ class ComposeLetterScreenBase extends React.Component<Props, State> {
       photoHeight: 200,
       open: false,
       valid: true,
+      saving: false,
+      savingOpacity: new Animated.Value(0),
     };
     this.updateWordsLeft = this.updateWordsLeft.bind(this);
     this.changeText = this.changeText.bind(this);
@@ -184,26 +189,29 @@ class ComposeLetterScreenBase extends React.Component<Props, State> {
   }
 
   registerPhoto(photo: Photo): void {
-    this.props.setPhoto(photo);
-    if (photo && photo.width && photo.height) {
-      if (photo.width < photo.height) {
-        this.setState({
-          photoWidth: (photo.width / photo.height) * 200,
-          photoHeight: 200,
-        });
+    this.setState({ saving: true }, () => {
+      this.props.setPhoto(photo);
+      if (photo && photo.width && photo.height) {
+        if (photo.width < photo.height) {
+          this.setState({
+            photoWidth: (photo.width / photo.height) * 200,
+            photoHeight: 200,
+          });
+        } else {
+          this.setState({
+            photoWidth: 200,
+            photoHeight: (photo.height / photo.width) * 200,
+          });
+        }
       } else {
         this.setState({
           photoWidth: 200,
-          photoHeight: (photo.height / photo.width) * 200,
+          photoHeight: 200,
         });
       }
-    } else {
-      this.setState({
-        photoWidth: 200,
-        photoHeight: 200,
-      });
-    }
-    Keyboard.dismiss();
+      Keyboard.dismiss();
+      this.setState({ saving: false });
+    });
   }
 
   deletePhoto(): void {
@@ -226,8 +234,23 @@ class ComposeLetterScreenBase extends React.Component<Props, State> {
   }
 
   changeText(value: string): void {
-    this.updateWordsLeft(value);
-    this.props.setContent(value);
+    this.setState({ saving: true }, () => {
+      Animated.timing(this.state.savingOpacity, {
+        toValue: 1.0,
+        duration: 0,
+        useNativeDriver: true,
+      }).start(() => {
+        this.updateWordsLeft(value);
+        this.props.setContent(value);
+        this.setState({ saving: false }, () => {
+          Animated.timing(this.state.savingOpacity, {
+            toValue: 0.0,
+            duration: 300,
+            useNativeDriver: true,
+          }).start();
+        });
+      });
+    });
   }
 
   render(): JSX.Element {
@@ -273,6 +296,16 @@ class ComposeLetterScreenBase extends React.Component<Props, State> {
               numLines={100}
               testId="input"
             >
+              <Animated.View
+                style={{
+                  position: 'absolute',
+                  top: 10,
+                  right: 10,
+                  opacity: this.state.savingOpacity,
+                }}
+              >
+                <Text>{this.state.saving ? 'saving' : 'saved'}</Text>
+              </Animated.View>
               <Animated.View
                 style={{
                   position: 'absolute',

--- a/src/views/Home/ContactSelector.react.tsx
+++ b/src/views/Home/ContactSelector.react.tsx
@@ -20,7 +20,7 @@ import ContactSelectorCard from '@components/Card/ContactSelectorCard.react';
 import { setActive } from '@store/Contact/ContactActions';
 import { getContacts, getUser } from '@api';
 import { dropdownError } from '@components/Dropdown/Dropdown.react';
-import { Notif, NotifActionTypes, NotifTypes } from '@store/Notif/NotifTypes';
+import { Notif, NotifActionTypes } from '@store/Notif/NotifTypes';
 import { handleNotif } from '@store/Notif/NotifiActions';
 import * as Segment from 'expo-analytics-segment';
 import Styles from './ContactSelector.styles';
@@ -40,6 +40,7 @@ interface Props {
   navigation: ContactSelectorScreenNavigationProp;
   setActiveContact: (contact: Contact) => void;
   currentNotif: Notif | null;
+  userPostal: string;
   handleNotif: () => void;
 }
 
@@ -88,6 +89,8 @@ class ContactSelectorScreenBase extends React.Component<Props, State> {
           this.props.setActiveContact(item);
           this.props.navigation.navigate('SingleContact');
         }}
+        userPostal={this.props.userPostal}
+        contactPostal={item.facility?.postal}
         key={item.inmateNumber}
       />
     );
@@ -163,13 +166,12 @@ class ContactSelectorScreenBase extends React.Component<Props, State> {
   }
 }
 
-const mapStateToProps = (state: AppState) => {
-  return {
-    existingContacts: state.contact.existing,
-    existingLetters: state.letter.existing,
-    currentNotif: state.notif.currentNotif,
-  };
-};
+const mapStateToProps = (state: AppState) => ({
+  existingContacts: state.contact.existing,
+  existingLetters: state.letter.existing,
+  currentNotif: state.notif.currentNotif,
+  userPostal: state.user.user.postal,
+});
 const mapDispatchToProps = (
   dispatch: Dispatch<ContactActionTypes | NotifActionTypes>
 ) => {

--- a/src/views/Home/SingleContact.react.tsx
+++ b/src/views/Home/SingleContact.react.tsx
@@ -211,7 +211,7 @@ class SingleContactScreenBase extends React.Component<Props, State> {
             >
               <Emoji name="airplane" />{' '}
               {i18n.t('SingleContactScreen.lettersTraveled')}:{' '}
-              {this.state.lettersTraveled} miles
+              {this.state.lettersTraveled} {i18n.t('miles')}
             </Text>
             <Button
               onPress={() => {

--- a/src/views/Home/SingleContact.react.tsx
+++ b/src/views/Home/SingleContact.react.tsx
@@ -239,7 +239,8 @@ class SingleContactScreenBase extends React.Component<Props, State> {
             <Text style={[Typography.FONT_REGULAR, Styles.profileCardInfo]}>
               <Emoji name="calendar" />{' '}
               {i18n.t('SingleContactScreen.lastHeardFromYou')}:{' '}
-              {letters.length > 0 &&
+              {letters &&
+                letters.length > 0 &&
                 letters[0].dateCreated &&
                 format(letters[0].dateCreated, 'MMM dd')}
             </Text>
@@ -252,7 +253,8 @@ class SingleContactScreenBase extends React.Component<Props, State> {
             >
               <Emoji name="airplane" />{' '}
               {i18n.t('SingleContactScreen.lettersTraveled')}:{' '}
-              {this.state.lettersTraveled} {i18n.t('miles')}
+              {this.state.lettersTraveled}{' '}
+              {i18n.t('ContactSelectorScreen.miles')}
             </Text>
             <Button
               onPress={() => {

--- a/test/components/Card/__snapshots__/ContactSelectorCard.test.tsx.snap
+++ b/test/components/Card/__snapshots__/ContactSelectorCard.test.tsx.snap
@@ -202,7 +202,10 @@ exports[`Contact Selector Card component should match snapshot 1`] = `
           </Text>
            
           letters traveled
-          :
+          : 
+          0
+           
+          miles
         </Text>
       </View>
     </View>

--- a/test/components/__snapshots__/ComposeHeader.test.tsx.snap
+++ b/test/components/__snapshots__/ComposeHeader.test.tsx.snap
@@ -44,6 +44,22 @@ exports[`ComposeHeader component should match snapshot 1`] = `
         : 
         Team A
       </Text>
+      <Text
+        style={
+          Array [
+            Object {
+              "fontFamily": "Poppins-Medium-Italic",
+            },
+            Object {
+              "color": "#9A9A9A",
+              "marginTop": 8,
+              "paddingRight": 16,
+            },
+          ]
+        }
+      >
+        autosaved
+      </Text>
       <TouchableOpacity
         activeOpacity={0.7}
         style={

--- a/test/components/__snapshots__/ComposeHeader.test.tsx.snap
+++ b/test/components/__snapshots__/ComposeHeader.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`ComposeHeader component should match snapshot 1`] = `
           ]
         }
       >
-        autosaved
+        Autosaved
       </Text>
       <TouchableOpacity
         activeOpacity={0.7}

--- a/test/views/Compose/__snapshots__/ComposeLetter.test.tsx.snap
+++ b/test/views/Compose/__snapshots__/ComposeLetter.test.tsx.snap
@@ -99,7 +99,7 @@ exports[`ComposeLetter screen should match snapshot 1`] = `
                 ]
               }
             >
-              autosaved
+              Autosaved
             </Text>
             <TouchableOpacity
               activeOpacity={0.7}

--- a/test/views/Compose/__snapshots__/ComposeLetter.test.tsx.snap
+++ b/test/views/Compose/__snapshots__/ComposeLetter.test.tsx.snap
@@ -84,6 +84,22 @@ exports[`ComposeLetter screen should match snapshot 1`] = `
               : 
               First Name
             </Text>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "fontFamily": "Poppins-Medium-Italic",
+                  },
+                  Object {
+                    "color": "#9A9A9A",
+                    "marginTop": 8,
+                    "paddingRight": 16,
+                  },
+                ]
+              }
+            >
+              autosaved
+            </Text>
             <TouchableOpacity
               activeOpacity={0.7}
               style={
@@ -227,6 +243,20 @@ exports[`ComposeLetter screen should match snapshot 1`] = `
                 }
               }
             />
+          </View>
+          <View
+            style={
+              Object {
+                "opacity": 1,
+                "position": "absolute",
+                "right": 10,
+                "top": 10,
+              }
+            }
+          >
+            <Text>
+              saved
+            </Text>
           </View>
           <View
             style={

--- a/test/views/Compose/__snapshots__/ComposePostcard.test.tsx.snap
+++ b/test/views/Compose/__snapshots__/ComposePostcard.test.tsx.snap
@@ -99,7 +99,7 @@ exports[`ComposePostcard screen should match snapshot 1`] = `
                 ]
               }
             >
-              autosaved
+              Autosaved
             </Text>
             <TouchableOpacity
               activeOpacity={0.7}

--- a/test/views/Compose/__snapshots__/ComposePostcard.test.tsx.snap
+++ b/test/views/Compose/__snapshots__/ComposePostcard.test.tsx.snap
@@ -84,6 +84,22 @@ exports[`ComposePostcard screen should match snapshot 1`] = `
               : 
               First Name
             </Text>
+            <Text
+              style={
+                Array [
+                  Object {
+                    "fontFamily": "Poppins-Medium-Italic",
+                  },
+                  Object {
+                    "color": "#9A9A9A",
+                    "marginTop": 8,
+                    "paddingRight": 16,
+                  },
+                ]
+              }
+            >
+              autosaved
+            </Text>
             <TouchableOpacity
               activeOpacity={0.7}
               style={

--- a/test/views/Home/ContactSelector.test.tsx
+++ b/test/views/Home/ContactSelector.test.tsx
@@ -45,6 +45,11 @@ const setup = (contactsOverrides = [], lettersOverrides = []) => {
     contact: initialContactState,
     letter: initialLetterState,
     notif: { currentNotif: null },
+    user: {
+      user: {
+        postal: '55419',
+      },
+    },
   });
 
   const StoreProvider = ({ children }: { children: JSX.Element }) => {

--- a/test/views/Home/__snapshots__/ContactSelector.test.tsx.snap
+++ b/test/views/Home/__snapshots__/ContactSelector.test.tsx.snap
@@ -270,7 +270,10 @@ exports[`Contact Selector Screen should match snapshot 1`] = `
                 </Text>
                  
                 letters traveled
-                :
+                : 
+                0
+                 
+                miles
               </Text>
             </View>
           </View>

--- a/test/views/Home/__snapshots__/SingleContact.test.tsx.snap
+++ b/test/views/Home/__snapshots__/SingleContact.test.tsx.snap
@@ -301,7 +301,8 @@ exports[`Single Contact Screen should match snapshot 1`] = `
           :
            
           0
-           miles
+           
+          miles
         </Text>
         <TouchableOpacity
           activeOpacity={0.7}

--- a/test/views/Home/__snapshots__/SingleContact.test.tsx.snap
+++ b/test/views/Home/__snapshots__/SingleContact.test.tsx.snap
@@ -300,6 +300,9 @@ exports[`Single Contact Screen should match snapshot 1`] = `
            
           letters traveled
           :
+           
+          0
+           miles
         </Text>
         <TouchableOpacity
           activeOpacity={0.7}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added in the functionality that will eventually support calculation of distance letters travelled. Added in text to the compose screen indicating that it autosaves.

## Description
<!--- Describe your changes in detail -->
Added a function to calculate the haversine distance using lats and longs. Plugged this in to components that had previously referenced `letters traveled` distance. Added text to the top of the compose screen (as suggested by design) to clearly indicate to users that their drafts autosave.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allow users to see how far their letters have travelled.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated existing tests. Still can't fully test bc API is not full with Zipcode info.

## Screenshots (if appropriate):
![Screenshot_1595978634](https://user-images.githubusercontent.com/54997453/88739262-2477dc80-d108-11ea-81d0-231a79cd2f3d.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
