### PR TITLE
[Image] Improve async image loading, feedback on compose screen

### DIFF
--- a/src/components/AsyncImage/AsyncImage.react.tsx
+++ b/src/components/AsyncImage/AsyncImage.react.tsx
@@ -37,7 +37,7 @@ class AsyncImage extends React.Component<Props, State> {
     viewStyle: { flex: 1 },
     imageStyle: { flex: 1 },
     loadingSize: 30,
-    timeout: 3000,
+    timeout: 10000,
     download: false,
   };
 

--- a/src/components/EditablePostcard/EditablePostcard.react.tsx
+++ b/src/components/EditablePostcard/EditablePostcard.react.tsx
@@ -15,6 +15,7 @@ interface Props {
   onChangeText: (text: string) => void;
   recipient: Contact;
   horizontal?: boolean;
+  onLoad?: () => void;
 }
 
 interface State {
@@ -87,7 +88,9 @@ class EditablePostcard extends React.Component<Props, State> {
             width: this.state.width,
             height: this.state.height,
           }}
-          source={this.props.design.image}
+          source={this.props.design.thumbnail || this.props.design.image}
+          onLoad={this.props.onLoad}
+          download={!!this.props.design.thumbnail}
         />
       );
     } else {
@@ -98,7 +101,9 @@ class EditablePostcard extends React.Component<Props, State> {
             height: this.state.width,
             transform: [{ rotateZ: '270deg' }],
           }}
-          source={this.props.design.image}
+          source={this.props.design.thumbnail || this.props.design.image}
+          onLoad={this.props.onLoad}
+          download={!!this.props.design.thumbnail}
         />
       );
     }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 import Alert from './Alert/Alert.react';
+import AsyncImage from './AsyncImage/AsyncImage.react';
 import Button from './Button/Button.react';
 import CategoryCard from './Card/CategoryCard.react';
 import ContactSelectorCard from './Card/ContactSelectorCard.react';
@@ -26,6 +27,7 @@ import Topbar from './Topbar/Topbar.react';
 
 export {
   Alert,
+  AsyncImage,
   Button,
   CategoryCard,
   ContactSelectorCard,

--- a/src/views/Compose/ComposePostcard.react.tsx
+++ b/src/views/Compose/ComposePostcard.react.tsx
@@ -8,6 +8,7 @@ import {
   Keyboard,
   EmitterSubscription,
   Platform,
+  Image as ImageComponent,
 } from 'react-native';
 import { EditablePostcard, ComposeTools, KeyboardAvoider } from '@components';
 import {
@@ -37,6 +38,7 @@ import { dropdownError } from '@components/Dropdown/Dropdown.react';
 import { popupAlert } from '@components/Alert/Alert.react';
 import AsyncImage from '@components/AsyncImage/AsyncImage.react';
 import * as Segment from 'expo-analytics-segment';
+import Loading from '@assets/common/loading.gif';
 import Styles from './Compose.styles';
 
 const FLIP_DURATION = 500;
@@ -65,6 +67,7 @@ interface State {
   data: Record<string, PostcardDesign[]>;
   subcategory: string;
   design: PostcardDesign;
+  loading?: PostcardDesign;
   writing: boolean;
   flip: Animated.Value;
   keyboardOpacity: Animated.Value;
@@ -254,6 +257,18 @@ class ComposePostcardScreenBase extends React.Component<Props, State> {
     }
   }
 
+  designIsHorizontal = (): boolean => {
+    const designWidth = this.state.design.image.width;
+    const designHeight = this.state.design.image.height;
+    if (!designWidth || !designHeight) {
+      return true;
+    }
+    if (designWidth > designHeight) {
+      return true;
+    }
+    return false;
+  };
+
   async loadData(): Promise<void> {
     if (this.props.route.params.category.name === 'personal') {
       const assets = await MediaLibrary.getAssetsAsync();
@@ -302,17 +317,18 @@ class ComposePostcardScreenBase extends React.Component<Props, State> {
   }
 
   changeDesign(design: PostcardDesign): void {
+    if (design === this.state.design) return;
     saveDraft(this.props.composing);
     this.props.setDesign(design);
-    this.setState({ design });
+    this.setState({ design, loading: design });
     if (
       design.image.width &&
       design.image.height &&
-      design.image.height > design.image.width
+      design.image.width > design.image.height
     ) {
-      this.setState({ horizontal: false });
-    } else {
       this.setState({ horizontal: true });
+    } else {
+      this.setState({ horizontal: false });
     }
     Segment.trackWithProperties('Compose - Add Image Success', {
       Option: 'Postcard',
@@ -359,6 +375,7 @@ class ComposePostcardScreenBase extends React.Component<Props, State> {
     Keyboard.dismiss();
     setBackOverride(undefined);
     this.changeDesign(this.state.design);
+    this.setState({ horizontal: this.designIsHorizontal() });
     Segment.trackWithProperties('Compose - Click on Back', {
       Option: 'Postcard',
       Step: 'Caption',
@@ -394,19 +411,8 @@ class ComposePostcardScreenBase extends React.Component<Props, State> {
       subcategory: this.state.design.subcategoryName,
       step: 'draft',
     });
-    const designIsHorizontal = (): boolean => {
-      const designWidth = this.state.design.image.width;
-      const designHeight = this.state.design.image.height;
-      if (!designWidth || !designHeight) {
-        return true;
-      }
-      if (designWidth > designHeight) {
-        return true;
-      }
-      return false;
-    };
     this.props.navigation.navigate('ReviewPostcard', {
-      horizontal: designIsHorizontal(),
+      horizontal: this.designIsHorizontal(),
       category: this.props.route.params.category.name,
     });
   }
@@ -500,7 +506,6 @@ class ComposePostcardScreenBase extends React.Component<Props, State> {
         onPress={() => this.changeDesign(design)}
       >
         <AsyncImage
-          download
           source={design.thumbnail ? design.thumbnail : design.image}
           imageStyle={{
             flex: 1,
@@ -508,6 +513,23 @@ class ComposePostcardScreenBase extends React.Component<Props, State> {
             overflow: 'hidden',
           }}
         />
+        {this.state.loading === design && (
+          <View
+            style={{
+              position: 'absolute',
+              width: '100%',
+              height: '100%',
+              justifyContent: 'center',
+              alignItems: 'center',
+              backgroundColor: 'rgba(0,0,0,0.6)',
+            }}
+          >
+            <ImageComponent
+              style={{ width: 40, height: 40 }}
+              source={Loading}
+            />
+          </View>
+        )}
       </TouchableOpacity>
     );
   }
@@ -561,6 +583,9 @@ class ComposePostcardScreenBase extends React.Component<Props, State> {
               flip={this.state.flip}
               onChangeText={this.changeText}
               horizontal={this.state.horizontal}
+              onLoad={() => {
+                this.setState({ loading: undefined });
+              }}
               active
             />
           </Animated.View>

--- a/src/views/Compose/ComposePostcard.react.tsx
+++ b/src/views/Compose/ComposePostcard.react.tsx
@@ -67,7 +67,7 @@ interface State {
   data: Record<string, PostcardDesign[]>;
   subcategory: string;
   design: PostcardDesign;
-  loading?: PostcardDesign;
+  loading: PostcardDesign | null;
   writing: boolean;
   flip: Animated.Value;
   keyboardOpacity: Animated.Value;
@@ -109,6 +109,7 @@ class ComposePostcardScreenBase extends React.Component<Props, State> {
       mediaGranted: true,
       renderMethod: 'grid',
       horizontal: true,
+      loading: null,
     };
 
     this.beginWriting = this.beginWriting.bind(this);
@@ -332,6 +333,7 @@ class ComposePostcardScreenBase extends React.Component<Props, State> {
     }
     Segment.trackWithProperties('Compose - Add Image Success', {
       Option: 'Postcard',
+      orientation: this.state.horizontal ? 'horizontal' : 'vertical',
     });
   }
 
@@ -584,7 +586,7 @@ class ComposePostcardScreenBase extends React.Component<Props, State> {
               onChangeText={this.changeText}
               horizontal={this.state.horizontal}
               onLoad={() => {
-                this.setState({ loading: undefined });
+                this.setState({ loading: null });
               }}
               active
             />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updated the `AsyncImage` component to better handle image loading in the compose flow without errors. Made support of variable width / height designs more graceful.

## Description
<!--- Describe your changes in detail -->
Changed how the state variables in `AsyncImage` are updated to change more smoothly. Added support for an `onLoad` call back so that the compose screen can show a loading indicator over the selected design until it is ready to be rendered in the preview.

NOTE: With the new changes, the initial load of the designs takes slightly longer. This will be fixed in my next PR, where I move the designs and categories into the redux store and prefetch.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #250 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Played around with it in my phone.