### PR TITLE
[Compose] Add redux to postcard categories/designs, small postcard bugs

### DIFF
--- a/src/api/Mail.ts
+++ b/src/api/Mail.ts
@@ -21,6 +21,7 @@ import { estimateDelivery } from '@utils';
 
 import { Image as ImageComponent } from 'react-native';
 import { number } from 'prop-types';
+import { setCategories, setLastUpdated } from '@store/Category/CategoryActions';
 import {
   getZipcode,
   fetchAuthenticated,
@@ -376,28 +377,17 @@ interface RawCategory {
   blurb: string;
 }
 
-function cleanCategory(raw: RawCategory): Category {
+function cleanCategory(
+  raw: RawCategory,
+  subcategories: Record<string, PostcardDesign[]>
+): Category {
   return {
     id: raw.id,
     name: raw.name,
     image: { uri: raw.img_src },
     blurb: raw.blurb,
+    subcategories,
   };
-}
-
-export async function getCategories(): Promise<Category[]> {
-  const body = await fetchAuthenticated(url.resolve(API_URL, 'categories'));
-  if (body.status !== 'OK' || !body.data) throw body;
-  const data = body.data as RawCategory[];
-  const categories: Category[] = data.map((raw: RawCategory) =>
-    cleanCategory(raw)
-  );
-  const personalIx = categories.findIndex(
-    (cat: Category) => cat.name === 'personal'
-  );
-  const personalCategory = categories.splice(personalIx, 1);
-  categories.unshift(personalCategory[0]);
-  return categories;
 }
 
 interface RawDesign {
@@ -445,27 +435,6 @@ async function cleanDesign(
   };
 }
 
-export async function getSubcategories(
-  category: Category
-): Promise<Record<string, PostcardDesign[]>> {
-  const body = await fetchAuthenticated(
-    url.resolve(API_URL, `designs/${category.id}`)
-  );
-  if (body.status !== 'OK' || !body.data) throw body;
-  const data = body.data as Record<string, RawDesign[]>;
-  const cleanData: Record<string, PostcardDesign[]> = {};
-  const subNames = Object.keys(data);
-  for (let ix = 0; ix < subNames.length; ix += 1) {
-    const subName = subNames[ix];
-    cleanData[subName] = await Promise.all(
-      data[subName].map((raw: RawDesign) =>
-        cleanDesign(raw, category.id, subName)
-      )
-    );
-  }
-  return cleanData;
-}
-
 export async function getSubcategoriesById(
   categoryId: number
 ): Promise<Record<string, PostcardDesign[]>> {
@@ -485,4 +454,24 @@ export async function getSubcategoriesById(
     );
   }
   return cleanData;
+}
+
+export async function getCategories(): Promise<Category[]> {
+  const body = await fetchAuthenticated(url.resolve(API_URL, 'categories'));
+  if (body.status !== 'OK' || !body.data) throw body;
+  const data = body.data as RawCategory[];
+  const categories: Category[] = await Promise.all(
+    data.map(async (raw: RawCategory) => {
+      const subcategories = await getSubcategoriesById(raw.id);
+      return cleanCategory(raw, subcategories);
+    })
+  );
+  const personalIx = categories.findIndex(
+    (cat: Category) => cat.name === 'personal'
+  );
+  const personalCategory = categories.splice(personalIx, 1);
+  categories.unshift(personalCategory[0]);
+  store.dispatch(setCategories(categories));
+  store.dispatch(setLastUpdated(new Date()));
+  return categories;
 }

--- a/src/api/Mail.ts
+++ b/src/api/Mail.ts
@@ -2,7 +2,7 @@
 /* eslint-disable camelcase */
 // The above is necessary because a lot of the responses from the server are forced snake case on us
 import store from '@store';
-import url, { resolve } from 'url';
+import url from 'url';
 import {
   Draft,
   Mail,
@@ -20,7 +20,6 @@ import { addBusinessDays } from 'date-fns';
 import { estimateDelivery } from '@utils';
 
 import { Image as ImageComponent } from 'react-native';
-import { number } from 'prop-types';
 import { setCategories, setLastUpdated } from '@store/Category/CategoryActions';
 import {
   getZipcode,
@@ -472,6 +471,6 @@ export async function getCategories(): Promise<Category[]> {
   const personalCategory = categories.splice(personalIx, 1);
   categories.unshift(personalCategory[0]);
   store.dispatch(setCategories(categories));
-  store.dispatch(setLastUpdated(new Date()));
+  store.dispatch(setLastUpdated(new Date().toDateString()));
   return categories;
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -16,7 +16,6 @@ import {
   getSingleMail,
   getTrackingEvents,
   getCategories,
-  getSubcategories,
 } from './Mail';
 
 import {
@@ -56,5 +55,4 @@ export {
   saveDraft,
   deleteDraft,
   loadDraft,
-  getSubcategories,
 };

--- a/src/store/Category/CategoryActions.tsx
+++ b/src/store/Category/CategoryActions.tsx
@@ -82,7 +82,7 @@ export function removeSubcategory(
   };
 }
 
-export function setLastUpdated(date: Date): CategoryActionTypes {
+export function setLastUpdated(date: string): CategoryActionTypes {
   return {
     type: SET_LAST_UPDATED,
     payload: date,

--- a/src/store/Category/CategoryActions.tsx
+++ b/src/store/Category/CategoryActions.tsx
@@ -1,0 +1,90 @@
+import { Category, PostcardDesign } from 'types';
+import {
+  SET_CATEGORIES,
+  ADD_CATEGORY,
+  SET_CATEGORY,
+  REMOVE_CATEGORY,
+  SET_SUBCATEGORIES,
+  ADD_SUBCATEGORY,
+  SET_SUBCATEGORY,
+  REMOVE_SUBCATEGORY,
+  CategoryActionTypes,
+  SET_LAST_UPDATED,
+} from './CategoryTypes';
+
+export function setCategories(categories: Category[]): CategoryActionTypes {
+  return {
+    type: SET_CATEGORIES,
+    payload: categories,
+  };
+}
+
+export function addCategory(category: Category): CategoryActionTypes {
+  return {
+    type: ADD_CATEGORY,
+    payload: category,
+  };
+}
+
+export function setCategory(category: Category): CategoryActionTypes {
+  return {
+    type: SET_CATEGORY,
+    payload: category,
+  };
+}
+
+export function removeCategory(category: Category): CategoryActionTypes {
+  return {
+    type: REMOVE_CATEGORY,
+    payload: category,
+  };
+}
+
+export function setSubcategories(
+  categoryId: number,
+  subcategories: Record<string, PostcardDesign[]>
+): CategoryActionTypes {
+  return {
+    type: SET_SUBCATEGORIES,
+    payload: { categoryId, subcategories },
+  };
+}
+
+export function addSubcategory(
+  categoryId: number,
+  name: string,
+  designs: PostcardDesign[]
+): CategoryActionTypes {
+  return {
+    type: ADD_SUBCATEGORY,
+    payload: { categoryId, name, designs },
+  };
+}
+
+export function setSubcategory(
+  categoryId: number,
+  name: string,
+  designs: PostcardDesign[]
+): CategoryActionTypes {
+  return {
+    type: SET_SUBCATEGORY,
+    payload: { categoryId, name, designs },
+  };
+}
+
+export function removeSubcategory(
+  categoryId: number,
+  name: string
+): CategoryActionTypes {
+  return {
+    type: REMOVE_SUBCATEGORY,
+    payload: { categoryId, name },
+  };
+}
+
+export function setLastUpdated(date: Date): CategoryActionTypes {
+  return {
+    type: SET_LAST_UPDATED,
+    payload: date,
+  };
+}

--- a/src/store/Category/CategoryReducer.tsx
+++ b/src/store/Category/CategoryReducer.tsx
@@ -24,13 +24,18 @@ export default function CategoryReducer(
 ): CategoryState {
   const currentState = { ...state };
   let ix = -1;
+  let categories: Category[] = [];
   switch (action.type) {
     case SET_CATEGORIES:
       currentState.categories = action.payload;
       return currentState;
     case ADD_CATEGORY:
-      currentState.categories.push(action.payload);
-      return currentState;
+      categories = [...currentState.categories];
+      categories.push(action.payload);
+      return {
+        ...currentState,
+        categories,
+      };
     case SET_CATEGORY:
       ix = currentState.categories.findIndex(
         (value: Category) => value.id === action.payload.id
@@ -39,12 +44,13 @@ export default function CategoryReducer(
       currentState.categories[ix] = action.payload;
       return currentState;
     case REMOVE_CATEGORY:
-      ix = currentState.categories.findIndex(
-        (value: Category) => value.id === action.payload.id
+      categories = currentState.categories.filter(
+        (value: Category) => value.id !== action.payload.id
       );
-      if (ix < 0) return currentState;
-      currentState.categories.splice(ix, 1);
-      return currentState;
+      return {
+        ...currentState,
+        categories,
+      };
     case SET_SUBCATEGORIES:
       ix = currentState.categories.findIndex(
         (value: Category) => value.id === action.payload.categoryId
@@ -69,12 +75,13 @@ export default function CategoryReducer(
         action.payload.designs;
       return currentState;
     case REMOVE_SUBCATEGORY:
-      ix = currentState.categories.findIndex(
-        (value: Category) => value.id === action.payload.categoryId
+      categories = currentState.categories.filter(
+        (value: Category) => value.id !== action.payload.categoryId
       );
-      if (ix < 0) return currentState;
-      delete currentState.categories[ix].subcategories[action.payload.name];
-      return currentState;
+      return {
+        ...currentState,
+        categories,
+      };
     case SET_LAST_UPDATED:
       currentState.lastUpdated = action.payload;
       return currentState;

--- a/src/store/Category/CategoryReducer.tsx
+++ b/src/store/Category/CategoryReducer.tsx
@@ -15,7 +15,7 @@ import {
 
 const initialState: CategoryState = {
   categories: [],
-  lastUpdated: new Date(),
+  lastUpdated: null,
 };
 
 export default function CategoryReducer(

--- a/src/store/Category/CategoryReducer.tsx
+++ b/src/store/Category/CategoryReducer.tsx
@@ -1,0 +1,84 @@
+import { Category } from 'types';
+import {
+  SET_CATEGORIES,
+  ADD_CATEGORY,
+  SET_CATEGORY,
+  REMOVE_CATEGORY,
+  SET_SUBCATEGORIES,
+  ADD_SUBCATEGORY,
+  SET_SUBCATEGORY,
+  REMOVE_SUBCATEGORY,
+  CategoryActionTypes,
+  CategoryState,
+  SET_LAST_UPDATED,
+} from './CategoryTypes';
+
+const initialState: CategoryState = {
+  categories: [],
+  lastUpdated: new Date(),
+};
+
+export default function CategoryReducer(
+  state = initialState,
+  action: CategoryActionTypes
+): CategoryState {
+  const currentState = { ...state };
+  let ix = -1;
+  switch (action.type) {
+    case SET_CATEGORIES:
+      currentState.categories = action.payload;
+      return currentState;
+    case ADD_CATEGORY:
+      currentState.categories.push(action.payload);
+      return currentState;
+    case SET_CATEGORY:
+      ix = currentState.categories.findIndex(
+        (value: Category) => value.id === action.payload.id
+      );
+      if (ix < 0) return currentState;
+      currentState.categories[ix] = action.payload;
+      return currentState;
+    case REMOVE_CATEGORY:
+      ix = currentState.categories.findIndex(
+        (value: Category) => value.id === action.payload.id
+      );
+      if (ix < 0) return currentState;
+      currentState.categories.splice(ix, 1);
+      return currentState;
+    case SET_SUBCATEGORIES:
+      ix = currentState.categories.findIndex(
+        (value: Category) => value.id === action.payload.categoryId
+      );
+      if (ix < 0) return currentState;
+      currentState.categories[ix].subcategories = action.payload.subcategories;
+      return currentState;
+    case ADD_SUBCATEGORY:
+      ix = currentState.categories.findIndex(
+        (value: Category) => value.id === action.payload.categoryId
+      );
+      if (ix < 0) return currentState;
+      currentState.categories[ix].subcategories[action.payload.name] =
+        action.payload.designs;
+      return currentState;
+    case SET_SUBCATEGORY:
+      ix = currentState.categories.findIndex(
+        (value: Category) => value.id === action.payload.categoryId
+      );
+      if (ix < 0) return currentState;
+      currentState.categories[ix].subcategories[action.payload.name] =
+        action.payload.designs;
+      return currentState;
+    case REMOVE_SUBCATEGORY:
+      ix = currentState.categories.findIndex(
+        (value: Category) => value.id === action.payload.categoryId
+      );
+      if (ix < 0) return currentState;
+      delete currentState.categories[ix].subcategories[action.payload.name];
+      return currentState;
+    case SET_LAST_UPDATED:
+      currentState.lastUpdated = action.payload;
+      return currentState;
+    default:
+      return state;
+  }
+}

--- a/src/store/Category/CategoryTypes.tsx
+++ b/src/store/Category/CategoryTypes.tsx
@@ -1,0 +1,77 @@
+import { Category, PostcardDesign } from 'types';
+
+export const SET_CATEGORIES = 'category/set_categories';
+export const ADD_CATEGORY = 'category/add_category';
+export const SET_CATEGORY = 'category/set_category';
+export const REMOVE_CATEGORY = 'category/remove_category';
+
+export const SET_SUBCATEGORIES = 'category/set_subcategories';
+export const ADD_SUBCATEGORY = 'category/add_subcategory';
+export const SET_SUBCATEGORY = 'category/set_subcategory';
+export const REMOVE_SUBCATEGORY = 'category/remove_subcategory';
+
+export const SET_LAST_UPDATED = 'cateogry/set_last_updated';
+
+export interface CategoryState {
+  categories: Category[];
+  lastUpdated: Date;
+}
+
+interface SetCategoriesAction {
+  type: typeof SET_CATEGORIES;
+  payload: Category[];
+}
+
+interface AddCategoryAction {
+  type: typeof ADD_CATEGORY;
+  payload: Category;
+}
+
+interface SetCategoryAction {
+  type: typeof SET_CATEGORY;
+  payload: Category;
+}
+
+interface RemoveCategoryAction {
+  type: typeof REMOVE_CATEGORY;
+  payload: Category;
+}
+
+interface SetSubcategoriesAction {
+  type: typeof SET_SUBCATEGORIES;
+  payload: {
+    categoryId: number;
+    subcategories: Record<string, PostcardDesign[]>;
+  };
+}
+
+interface AddSubcategoryAction {
+  type: typeof ADD_SUBCATEGORY;
+  payload: { categoryId: number; name: string; designs: PostcardDesign[] };
+}
+
+interface SetSubcategoryAction {
+  type: typeof SET_SUBCATEGORY;
+  payload: { categoryId: number; name: string; designs: PostcardDesign[] };
+}
+
+interface RemoveSubcategoryAction {
+  type: typeof REMOVE_SUBCATEGORY;
+  payload: { categoryId: number; name: string };
+}
+
+interface SetLastUpdatedAction {
+  type: typeof SET_LAST_UPDATED;
+  payload: Date;
+}
+
+export type CategoryActionTypes =
+  | SetCategoriesAction
+  | AddCategoryAction
+  | SetCategoryAction
+  | RemoveCategoryAction
+  | SetSubcategoriesAction
+  | AddSubcategoryAction
+  | SetSubcategoryAction
+  | RemoveSubcategoryAction
+  | SetLastUpdatedAction;

--- a/src/store/Category/CategoryTypes.tsx
+++ b/src/store/Category/CategoryTypes.tsx
@@ -14,7 +14,7 @@ export const SET_LAST_UPDATED = 'cateogry/set_last_updated';
 
 export interface CategoryState {
   categories: Category[];
-  lastUpdated: Date;
+  lastUpdated: string | null;
 }
 
 interface SetCategoriesAction {
@@ -62,7 +62,7 @@ interface RemoveSubcategoryAction {
 
 interface SetLastUpdatedAction {
   type: typeof SET_LAST_UPDATED;
-  payload: Date;
+  payload: string;
 }
 
 export type CategoryActionTypes =

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,6 +2,7 @@ import { combineReducers, createStore } from 'redux';
 import { persistStore, persistReducer } from 'redux-persist';
 import { AsyncStorage } from 'react-native';
 import { AppState } from './types';
+import CategoryReducer from './Category/CategoryReducer';
 import ContactReducer from './Contact/ContactReducer';
 import MailReducer from './Mail/MailReducer';
 import NotifReducer from './Notif/NotifReducer';
@@ -11,11 +12,12 @@ const config = {
   key: 'root',
   storage: AsyncStorage,
   blacklist: ['user'],
-  whitelist: ['contact', 'notif', 'mail'],
+  whitelist: ['category', 'contact', 'notif', 'mail'],
 };
 
 const combinedReducers = combineReducers<AppState>({
   user: UserReducer,
+  category: CategoryReducer,
   contact: ContactReducer,
   notif: NotifReducer,
   mail: MailReducer,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,9 +1,11 @@
+import { CategoryState } from './Category/CategoryTypes';
 import { ContactState } from './Contact/ContactTypes';
 import { MailState } from './Mail/MailTypes';
 import { NotifState } from './Notif/NotifTypes';
 import { UserState } from './User/UserTypes';
 
 export interface AppState {
+  category: CategoryState;
   contact: ContactState;
   mail: MailState;
   notif: NotifState;

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export interface Category {
   name: string;
   image: Image;
   blurb: string;
+  subcategories: Record<string, PostcardDesign[]>;
 }
 
 // Letters and Postcards (Draft)

--- a/src/views/Compose/ChooseCategory.react.tsx
+++ b/src/views/Compose/ChooseCategory.react.tsx
@@ -24,10 +24,10 @@ interface Props {
   navigation: ChooseCategoryScreenNavigationProp;
   recipientId: number;
   setComposing: (draft: Draft) => void;
+  categories: Category[];
 }
 
 interface State {
-  categories: Category[];
   refreshing: boolean;
 }
 
@@ -35,23 +35,17 @@ class ChooseCategoryScreenBase extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
-      categories: [],
       refreshing: true,
     };
     this.renderCategory = this.renderCategory.bind(this);
     this.refreshCategories = this.refreshCategories.bind(this);
   }
 
-  async componentDidMount() {
-    await this.refreshCategories();
-  }
-
   async refreshCategories() {
     this.setState({ refreshing: true }, async () => {
       try {
-        const categories = await getCategories();
+        await getCategories();
         this.setState({
-          categories,
           refreshing: false,
         });
       } catch (err) {
@@ -87,11 +81,11 @@ class ChooseCategoryScreenBase extends React.Component<Props, State> {
           {i18n.t('Compose.iWouldLikeToSend')}
         </Text>
         <FlatList
-          data={this.state.categories.slice(1)}
+          data={this.props.categories.slice(1)}
           ListHeaderComponent={
-            this.state.categories.length > 0 ? (
+            this.props.categories.length > 0 ? (
               <CategoryCard
-                category={this.state.categories[0]}
+                category={this.props.categories[0]}
                 navigate={
                   this.props.navigation.navigate as (
                     val: string,
@@ -116,6 +110,7 @@ class ChooseCategoryScreenBase extends React.Component<Props, State> {
 
 const mapStateToProps = (state: AppState) => ({
   recipientId: state.contact.active.id,
+  categories: state.category.categories,
 });
 const mapDispatchToProps = (dispatch: Dispatch<MailActionTypes>) => {
   return {

--- a/src/views/Compose/ChooseOption.react.tsx
+++ b/src/views/Compose/ChooseOption.react.tsx
@@ -64,6 +64,7 @@ const ChooseOptionScreenBase: React.FC<Props> = (props: Props) => {
               id: -1,
               image: { uri: '' },
               blurb: '',
+              subcategories: {},
             },
           });
         }}

--- a/src/views/Home/ContactSelector.react.tsx
+++ b/src/views/Home/ContactSelector.react.tsx
@@ -38,7 +38,7 @@ interface Props {
   userPostal: string;
   handleNotif: () => void;
   userId: number;
-  lastUpdatedCategories: Date;
+  lastUpdatedCategories: string | null;
 }
 
 class ContactSelectorScreenBase extends React.Component<Props, State> {
@@ -78,7 +78,13 @@ class ContactSelectorScreenBase extends React.Component<Props, State> {
       this.props.navigation.replace('ContactInfo', {});
     }
     await this.doRefresh();
-    if (differenceInHours(this.props.lastUpdatedCategories, new Date()) > 6) {
+    if (
+      !this.props.lastUpdatedCategories ||
+      differenceInHours(
+        new Date(this.props.lastUpdatedCategories),
+        new Date()
+      ) > 6
+    ) {
       getCategories();
     }
   }

--- a/src/views/Home/ContactSelector.react.tsx
+++ b/src/views/Home/ContactSelector.react.tsx
@@ -11,12 +11,13 @@ import { Mail, Contact } from 'types';
 import i18n from '@i18n';
 import ContactSelectorCard from '@components/Card/ContactSelectorCard.react';
 import { setActive } from '@store/Contact/ContactActions';
-import { getContacts, getUser, uploadPushToken } from '@api';
+import { getContacts, getUser, uploadPushToken, getCategories } from '@api';
 import { dropdownError } from '@components/Dropdown/Dropdown.react';
 import { Notif, NotifActionTypes } from '@store/Notif/NotifTypes';
 import { handleNotif } from '@store/Notif/NotifiActions';
 import * as Segment from 'expo-analytics-segment';
 import Notifs from '@notifications';
+import { differenceInHours } from 'date-fns';
 import Styles from './ContactSelector.styles';
 
 type ContactSelectorScreenNavigationProp = StackNavigationProp<
@@ -37,6 +38,7 @@ interface Props {
   userPostal: string;
   handleNotif: () => void;
   userId: number;
+  lastUpdatedCategories: Date;
 }
 
 class ContactSelectorScreenBase extends React.Component<Props, State> {
@@ -76,6 +78,9 @@ class ContactSelectorScreenBase extends React.Component<Props, State> {
       this.props.navigation.replace('ContactInfo', {});
     }
     await this.doRefresh();
+    if (differenceInHours(this.props.lastUpdatedCategories, new Date()) > 6) {
+      getCategories();
+    }
   }
 
   async doRefresh() {
@@ -177,6 +182,7 @@ const mapStateToProps = (state: AppState) => ({
   currentNotif: state.notif.currentNotif,
   userPostal: state.user.user.postal,
   userId: state.user.user.id,
+  lastUpdatedCategories: state.category.lastUpdated,
 });
 const mapDispatchToProps = (
   dispatch: Dispatch<ContactActionTypes | NotifActionTypes>

--- a/src/views/Home/SingleContact.react.tsx
+++ b/src/views/Home/SingleContact.react.tsx
@@ -305,6 +305,7 @@ class SingleContactScreenBase extends React.Component<Props, State> {
                                       id: -1,
                                       image: { uri: '' },
                                       blurb: '',
+                                      subcategories: {},
                                     },
                                   }
                                 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Implemented a redux store for categories and designs so that requests do not have to be made to the server everytime. Allowed users to load more than their first 20 personal photos. Added support for the compose bar back to postcards on iOS.

## Description
<!--- Describe your changes in detail -->
Slightly modified the category type to be supported in the redux store. The postcard designs will be asynchronously refreshed automatically every six hours. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #260 
Closes #278 
Makes the choose category screen faster, reduce calls.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Playing around with the designs and compose flow on my phone.