### PR TITLE
[Bug][AddContact] enforce name + inmate number char limit

### DIFF
--- a/src/components/Input/Input.react.tsx
+++ b/src/components/Input/Input.react.tsx
@@ -49,6 +49,7 @@ export interface Props {
   mustMatch?: string;
   trimWhitespace: boolean;
   strictDropdown: boolean;
+  isInvalidInput: () => boolean; // additional validation if neighboring input is needed
 }
 
 export interface State {
@@ -64,10 +65,6 @@ export interface State {
 
 class Input extends React.Component<Props, State> {
   private inputRef = createRef<TextInput>();
-
-  private scrollRef = createRef<ScrollView>();
-
-  private childrenIds: number[];
 
   static defaultProps = {
     parentStyle: {},
@@ -91,11 +88,11 @@ class Input extends React.Component<Props, State> {
     required: false,
     trimWhitespace: true,
     strictDropdown: false,
+    isInvalidInput: (): null => null,
   };
 
   constructor(props: Props) {
     super(props);
-    this.childrenIds = [];
     this.state = {
       value: '',
       focused: false,
@@ -159,7 +156,14 @@ class Input extends React.Component<Props, State> {
 
   doValidate = (): void => {
     const { value } = this.state;
-    const { required, validate, onValid, onInvalid, mustMatch } = this.props;
+    const {
+      required,
+      validate,
+      onValid,
+      onInvalid,
+      mustMatch,
+      isInvalidInput,
+    } = this.props;
     let result = true;
     if (value || validate || required) {
       if (validate) {
@@ -173,6 +177,9 @@ class Input extends React.Component<Props, State> {
     }
     if (mustMatch) {
       result = result && mustMatch === value;
+    }
+    if (isInvalidInput()) {
+      result = false;
     }
     if (!required && value === '') {
       result = true;

--- a/src/components/Input/Input.react.tsx
+++ b/src/components/Input/Input.react.tsx
@@ -88,7 +88,7 @@ class Input extends React.Component<Props, State> {
     required: false,
     trimWhitespace: true,
     strictDropdown: false,
-    isInvalidInput: (): null => null,
+    isInvalidInput: (): false => false,
   };
 
   constructor(props: Props) {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -53,6 +53,7 @@
     "federal": "Federal",
     "firstName": "First Name",
     "lastName": "Last Name",
+    "nameTooLong": "Oops, your loved one's name is a bit too long! Could you please abbreviate?",
     "inmateNumber": "Inmate Number",
     "relationshipToInmate": "I am their..",
     "state": "State",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -53,6 +53,7 @@
     "federal": "Federal",
     "firstName": "Nombre",
     "lastName": "Apellido",
+    "nameTooLong": "¡Ay, el nombre de su ser querido es un poco largo! ¿Podría abreviar?",
     "inmateNumber": "Número de preso",
     "relationshipToInmate": "Yo soy su",
     "state": "Estado",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -182,6 +182,8 @@ export function validateFormat(format: Validation, value: string): boolean {
   }
 }
 
+export const LOB_NAME_CHAR_LIMIT = 37; // excluding spaces
+
 export {
   ABBREV_TO_STATE,
   STATE_TO_ABBREV,

--- a/src/views/AddContact/ContactInfo.react.tsx
+++ b/src/views/AddContact/ContactInfo.react.tsx
@@ -383,7 +383,9 @@ class ContactInfoScreenBase extends React.Component<Props, State> {
                   isInvalidInput={this.isExceedsNameCharLimit}
                 />
                 {this.isExceedsNameCharLimit() && (
-                  <Text>{i18n.t('ContactInfoScreen.nameTooLong')}</Text>
+                  <Text style={{ textAlign: 'center', marginBottom: 5 }}>
+                    {i18n.t('ContactInfoScreen.nameTooLong')}
+                  </Text>
                 )}
                 <Input
                   ref={this.inmateNumber}

--- a/src/views/AddContact/ContactInfo.react.tsx
+++ b/src/views/AddContact/ContactInfo.react.tsx
@@ -11,6 +11,7 @@ import { Colors, Typography } from '@styles';
 import { AppStackParamList } from '@navigations';
 import { StackNavigationProp } from '@react-navigation/stack';
 import {
+  LOB_NAME_CHAR_LIMIT,
   STATE_TO_ABBREV,
   STATE_TO_INMATE_DB,
   STATES_DROPDOWN,
@@ -81,6 +82,7 @@ class ContactInfoScreenBase extends React.Component<Props, State> {
       'blur',
       this.onNavigationBlur
     );
+    this.isExceedsNameCharLimit = this.isExceedsNameCharLimit.bind(this);
   }
 
   componentDidMount() {
@@ -217,6 +219,22 @@ class ContactInfoScreenBase extends React.Component<Props, State> {
     }
   }
 
+  isExceedsNameCharLimit() {
+    if (
+      this.firstName.current &&
+      this.lastName.current &&
+      this.inmateNumber.current
+    ) {
+      return (
+        this.firstName.current.state.value.length +
+          this.lastName.current.state.value.length +
+          this.inmateNumber.current.state.value.length >
+        LOB_NAME_CHAR_LIMIT
+      );
+    }
+    return false;
+  }
+
   render() {
     const inmateDatabaseLink =
       STATE_TO_INMATE_DB[STATE_TO_ABBREV[this.state.stateToSearch]]?.link;
@@ -339,25 +357,48 @@ class ContactInfoScreenBase extends React.Component<Props, State> {
                   parentStyle={CommonStyles.fullWidth}
                   placeholder={i18n.t('ContactInfoScreen.firstName')}
                   required
+                  onChangeText={() => {
+                    if (this.lastName.current) {
+                      this.lastName.current.doValidate();
+                    }
+                  }}
                   onValid={this.updateValid}
                   onInvalid={() => this.setValid(false)}
                   nextInput={this.lastName}
+                  isInvalidInput={this.isExceedsNameCharLimit}
                 />
                 <Input
                   ref={this.lastName}
                   parentStyle={CommonStyles.fullWidth}
                   placeholder={i18n.t('ContactInfoScreen.lastName')}
                   required
+                  onChangeText={() => {
+                    if (this.firstName.current) {
+                      this.firstName.current.doValidate();
+                    }
+                  }}
                   onValid={this.updateValid}
                   onInvalid={() => this.setValid(false)}
                   nextInput={this.inmateNumber}
+                  isInvalidInput={this.isExceedsNameCharLimit}
                 />
+                {this.isExceedsNameCharLimit() && (
+                  <Text>{i18n.t('ContactInfoScreen.nameTooLong')}</Text>
+                )}
                 <Input
                   ref={this.inmateNumber}
                   parentStyle={CommonStyles.fullWidth}
                   placeholder={i18n.t('ContactInfoScreen.inmateNumber')}
                   required
                   validate={Validation.InmateNumber}
+                  onChangeText={() => {
+                    if (this.firstName.current) {
+                      this.firstName.current.doValidate();
+                    }
+                    if (this.lastName.current) {
+                      this.lastName.current.doValidate();
+                    }
+                  }}
                   onValid={this.updateValid}
                   onInvalid={() => this.setValid(false)}
                   nextInput={this.relationship}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- add `isInvalidInput` prop to `Input` component. This allows neighboring input to be used for validation purposes, and checks for validity on top of existing checks (doesn't overwrite). (it could probably also be ised for matching passwords ?)
- change ContactInformation screen to enforce char limit

(for those curious it turns out the fun fun issues i was having were due to me using both the Input components' state and ContactInfo class's state to keep track of firstName, lastName, etc., and them not updating like i expected em to. yay asynchronous updates !)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #267 

## Screenshots (if appropriate):
- firstName & lastName boxes turn red if car limit exceeded (inmateNumber isn't affected)
- responsive to changes in all 3
- message pops up under Name and above inmateNumber

https://drive.google.com/file/d/10u2jGWnRx34ha5RJV-cX6KBY69R0WCbI/view?usp=sharing

note: i changed text alignment to center and added margin under the err msg
![image](https://user-images.githubusercontent.com/63126090/92200061-71a14980-ee3e-11ea-9e05-1a4e0b453063.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)