### PR TITLE
make photo library start at most recent

### DIFF
--- a/src/views/Compose/ComposePostcard.react.tsx
+++ b/src/views/Compose/ComposePostcard.react.tsx
@@ -225,7 +225,9 @@ class ComposePostcardScreenBase extends React.Component<Props, State> {
           assets,
           hasNextPage,
           endCursor,
-        } = await MediaLibrary.getAssetsAsync();
+        } = await MediaLibrary.getAssetsAsync({
+          sortBy: [[MediaLibrary.SortBy.creationTime, false]],
+        });
         const library = assets.map((value) => {
           const image: Image = {
             uri: value.uri,
@@ -343,7 +345,10 @@ class ComposePostcardScreenBase extends React.Component<Props, State> {
       assets,
       hasNextPage,
       endCursor,
-    } = await MediaLibrary.getAssetsAsync({ after: this.state.endCursor });
+    } = await MediaLibrary.getAssetsAsync({
+      after: this.state.endCursor,
+      sortBy: [[MediaLibrary.SortBy.creationTime, false]],
+    });
     const library = this.props.route.params.category.subcategories.Library;
     if (!library) return;
     const designs = assets.map((value) => {


### PR DESCRIPTION
- before: "Library" section shows photos from beginning of camera roll, so u have to scroll all the way to the bottom to get the photos u want ;(
- after: shows most recent photos first