### PR TITLE
[API] Add redux zip, bug fixes to avoid rate limits

### DIFF
--- a/src/api/Common.ts
+++ b/src/api/Common.ts
@@ -10,6 +10,7 @@ import {
 import { Image, ZipcodeInfo } from 'types';
 import { Platform } from 'react-native';
 import { ABBREV_TO_STATE, isProduction } from '@utils';
+import { setZipcode } from '@store/Zip/ZipActions';
 
 export const GENERAL_URL = isProduction()
   ? 'https://api.ameelio.org/'
@@ -156,6 +157,9 @@ export async function uploadImage(
 }
 
 export async function getZipcode(zipcode: string): Promise<ZipcodeInfo> {
+  if (Object.keys(store.getState().zip.zips).indexOf(zipcode) >= 0) {
+    return store.getState().zip.zips[zipcode];
+  }
   const body = await fetchAuthenticated(
     url.resolve(API_URL, `zips/${zipcode}`),
     {
@@ -170,11 +174,13 @@ export async function getZipcode(zipcode: string): Promise<ZipcodeInfo> {
     lat: string;
     lng: string;
   };
-  return {
+  const resultInfo = {
     zip: data.zip,
     city: data.city,
     state: ABBREV_TO_STATE[data.state_id],
     lat: parseFloat(data.lat),
     long: parseFloat(data.lng),
   };
+  store.dispatch(setZipcode(zipcode, resultInfo));
+  return resultInfo;
 }

--- a/src/api/Mail.ts
+++ b/src/api/Mail.ts
@@ -484,6 +484,6 @@ export async function getCategories(): Promise<Category[]> {
   const personalCategory = categories.splice(personalIx, 1);
   categories.unshift(personalCategory[0]);
   store.dispatch(setCategories(categories));
-  store.dispatch(setLastUpdated(new Date().toDateString()));
+  store.dispatch(setLastUpdated(new Date().toISOString()));
   return categories;
 }

--- a/src/api/User.ts
+++ b/src/api/User.ts
@@ -254,7 +254,7 @@ export async function login(cred: UserLoginInfo): Promise<User> {
   }
   store.dispatch(loginUser(userData));
   getCategories().catch(() => {
-    /* do nothing */
+    dropdownError({ message: i18n.t('Error.cantRefreshCategories') });
   });
   return userData;
 }

--- a/src/api/User.ts
+++ b/src/api/User.ts
@@ -207,7 +207,9 @@ export async function loginWithToken(): Promise<User> {
     await Promise.all([getContacts(), getMail()]);
     store.dispatch(loginUser(userData));
     await loadDraft();
-    getCategories();
+    getCategories().catch(() => {
+      /* do nothing */
+    });
     return userData;
   } catch (err) {
     store.dispatch(logoutUser());
@@ -246,12 +248,14 @@ export async function login(cred: UserLoginInfo): Promise<User> {
   );
   try {
     await Promise.all([getContacts(), getMail()]);
+    await loadDraft();
   } catch (err) {
     dropdownError({ message: i18n.t('Error.loadingUser') });
   }
   store.dispatch(loginUser(userData));
-  await loadDraft();
-  getCategories();
+  getCategories().catch(() => {
+    /* do nothing */
+  });
   return userData;
 }
 

--- a/src/store/Zip/ZipActions.tsx
+++ b/src/store/Zip/ZipActions.tsx
@@ -1,0 +1,21 @@
+import { ZipcodeInfo } from 'types';
+import { SET_ZIPCODES, SET_ZIPCODE, ZipActionTypes } from './ZipTypes';
+
+export function setZipcodes(
+  zipcodes: Record<string, ZipcodeInfo>
+): ZipActionTypes {
+  return {
+    type: SET_ZIPCODES,
+    payload: zipcodes,
+  };
+}
+
+export function setZipcode(zip: string, info: ZipcodeInfo): ZipActionTypes {
+  return {
+    type: SET_ZIPCODE,
+    payload: {
+      zip,
+      info,
+    },
+  };
+}

--- a/src/store/Zip/ZipReducer.tsx
+++ b/src/store/Zip/ZipReducer.tsx
@@ -1,0 +1,27 @@
+import {
+  SET_ZIPCODES,
+  SET_ZIPCODE,
+  ZipActionTypes,
+  ZipState,
+} from './ZipTypes';
+
+const initialState: ZipState = {
+  zips: {},
+};
+
+export default function ZipReducer(
+  state = initialState,
+  action: ZipActionTypes
+): ZipState {
+  const currentState = { ...state };
+  switch (action.type) {
+    case SET_ZIPCODES:
+      currentState.zips = action.payload;
+      return currentState;
+    case SET_ZIPCODE:
+      currentState.zips[action.payload.zip] = action.payload.info;
+      return currentState;
+    default:
+      return currentState;
+  }
+}

--- a/src/store/Zip/ZipTypes.tsx
+++ b/src/store/Zip/ZipTypes.tsx
@@ -1,0 +1,23 @@
+import { ZipcodeInfo } from 'types';
+
+export const SET_ZIPCODES = 'zip/set_zipcodes';
+export const SET_ZIPCODE = 'zip/set_zipcode';
+
+export interface ZipState {
+  zips: Record<string, ZipcodeInfo>;
+}
+
+interface SetZipcodesAction {
+  type: typeof SET_ZIPCODES;
+  payload: Record<string, ZipcodeInfo>;
+}
+
+interface SetZipcodeAction {
+  type: typeof SET_ZIPCODE;
+  payload: {
+    zip: string;
+    info: ZipcodeInfo;
+  };
+}
+
+export type ZipActionTypes = SetZipcodesAction | SetZipcodeAction;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -8,12 +8,13 @@ import FacilityReducer from './Facility/FacilityReducer';
 import MailReducer from './Mail/MailReducer';
 import NotifReducer from './Notif/NotifReducer';
 import UserReducer from './User/UserReducer';
+import ZipReducer from './Zip/ZipReducer';
 
 const config = {
   key: 'root',
   storage: AsyncStorage,
   blacklist: ['user', 'facility'],
-  whitelist: ['category', 'contact', 'notif', 'mail'],
+  whitelist: ['category', 'contact', 'notif', 'mail', 'zip'],
 };
 
 const combinedReducers = combineReducers<AppState>({
@@ -21,8 +22,9 @@ const combinedReducers = combineReducers<AppState>({
   category: CategoryReducer,
   contact: ContactReducer,
   facility: FacilityReducer,
-  notif: NotifReducer,
   mail: MailReducer,
+  notif: NotifReducer,
+  zip: ZipReducer,
 });
 
 const persistedReducers = persistReducer(config, combinedReducers);

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -4,6 +4,7 @@ import { FacilityState } from './Facility/FacilityTypes';
 import { MailState } from './Mail/MailTypes';
 import { NotifState } from './Notif/NotifTypes';
 import { UserState } from './User/UserTypes';
+import { ZipState } from './Zip/ZipTypes';
 
 export interface AppState {
   category: CategoryState;
@@ -12,4 +13,5 @@ export interface AppState {
   mail: MailState;
   notif: NotifState;
   user: UserState;
+  zip: ZipState;
 }

--- a/src/views/Home/ContactSelector.react.tsx
+++ b/src/views/Home/ContactSelector.react.tsx
@@ -84,7 +84,9 @@ class ContactSelectorScreenBase extends React.Component<Props, State> {
         new Date(this.props.lastUpdatedCategories)
       ) > 6
     ) {
-      getCategories();
+      getCategories().catch(() => {
+        dropdownError({ message: i18n.t('Error.cantRefreshCategories') });
+      });
     }
   }
 


### PR DESCRIPTION
Edit the api to reduce the amount of calls to the backend.

## Description
<!--- Describe your changes in detail -->
Added a section to the redux store to keep track of zip info so duplicate calls are not made.

Fixed the way that the date of last category update is tracked so that it does not make a call to get categories within 6 hours of the last update.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prevent rate limits from being hit as often. Improve performance of app, better when bad / no wifi.