### PR TITLE
[Compose] letter supports multiple images

### DIFF
--- a/src/api/Mail.ts
+++ b/src/api/Mail.ts
@@ -102,7 +102,7 @@ export function mapTrackingEventsToMailStatus(
 async function cleanMail(mail: RawMail): Promise<Mail> {
   const { type, content, id } = mail;
   const recipientId = mail.contact_id;
-  let images;
+  let images: Image[] = [];
   if (mail.images.length) {
     try {
       images = await Promise.all(
@@ -199,7 +199,7 @@ async function cleanMassMail(mail: RawMail): Promise<Mail> {
   }
   const { type, content, id } = mail;
   const recipientId = mail.contact_id;
-  let images;
+  let images: Image[] = [];
   if (mail.images.length) {
     try {
       images = await Promise.all(
@@ -351,7 +351,7 @@ export async function createMail(draft: Draft): Promise<Mail> {
       };
       throw uploadError;
     }
-  } else if (prepDraft.images && prepDraft.images.length) {
+  } else if (prepDraft.images.length) {
     try {
       const uris = await Promise.all(
         prepDraft.images.map(async (image) => {

--- a/src/api/Mail.ts
+++ b/src/api/Mail.ts
@@ -17,9 +17,8 @@ import { setUser } from '@store/User/UserActions';
 import { popupAlert } from '@components/Alert/Alert.react';
 import i18n from '@i18n';
 import { addBusinessDays } from 'date-fns';
-import { estimateDelivery } from '@utils';
+import { estimateDelivery, getImageDims } from '@utils';
 
-import { Image as ImageComponent } from 'react-native';
 import { setCategories, setLastUpdated } from '@store/Category/CategoryActions';
 import {
   getZipcode,
@@ -102,12 +101,9 @@ export function mapTrackingEventsToMailStatus(
 async function cleanMail(mail: RawMail): Promise<Mail> {
   const { type, content, id } = mail;
   const recipientId = mail.contact_id;
-  const image =
-    mail.images.length > 0
-      ? {
-          uri: mail.images[0].img_src,
-        }
-      : undefined;
+  const images = mail.images.length
+    ? mail.images.map((rawImage) => ({ uri: rawImage.img_src }))
+    : undefined;
   const design =
     mail.images.length > 0
       ? {
@@ -152,7 +148,7 @@ async function cleanMail(mail: RawMail): Promise<Mail> {
       status,
       dateCreated,
       expectedDelivery,
-      image,
+      images,
       trackingEvents,
     };
   }
@@ -186,12 +182,9 @@ async function cleanMassMail(mail: RawMail): Promise<Mail> {
   }
   const { type, content, id } = mail;
   const recipientId = mail.contact_id;
-  const image =
-    mail.images.length > 0
-      ? {
-          uri: mail.images[0].img_src,
-        }
-      : undefined;
+  const images = mail.images.length
+    ? mail.images.map((rawImage) => ({ uri: rawImage.img_src }))
+    : undefined;
   const design =
     mail.images.length > 0
       ? {
@@ -232,7 +225,7 @@ async function cleanMassMail(mail: RawMail): Promise<Mail> {
       status,
       dateCreated,
       expectedDelivery,
-      image,
+      images,
     };
   }
   return {
@@ -327,11 +320,15 @@ export async function createMail(draft: Draft): Promise<Mail> {
       };
       throw uploadError;
     }
-  } else if (prepDraft.image) {
+  } else if (prepDraft.images && prepDraft.images.length) {
     try {
-      prepDraft.image = await uploadImage(prepDraft.image, 'letter');
+      const uris = await Promise.all(
+        prepDraft.images.map(async (image) => {
+          return (await uploadImage(image, 'letter')).uri;
+        })
+      );
       imageExtension = {
-        s3_img_urls: [prepDraft.image?.uri],
+        s3_img_urls: uris,
       };
     } catch (err) {
       const uploadError: ApiResponse = {
@@ -406,19 +403,6 @@ async function cleanDesign(
   categoryId?: number,
   subcategoryName?: string
 ): Promise<PostcardDesign> {
-  const getImageDims = (
-    uri: string
-  ): Promise<{ width: number; height: number }> => {
-    return new Promise((res, rej) => {
-      ImageComponent.getSize(
-        uri,
-        (width, height) => {
-          res({ width, height });
-        },
-        rej
-      );
-    });
-  };
   try {
     const imageDims = await getImageDims(raw.front_img_src);
     const thumbnailDims = await getImageDims(raw.thumbnail_src);

--- a/src/api/User.ts
+++ b/src/api/User.ts
@@ -78,6 +78,7 @@ export async function deleteDraft(): Promise<void> {
   await deleteItemAsync(Storage.DraftType);
   await deleteItemAsync(Storage.DraftContent);
   await deleteItemAsync(Storage.DraftRecipientId);
+  await deleteItemAsync(Storage.DraftImages);
   await deleteItemAsync(Storage.DraftDesignUri);
   await deleteItemAsync(Storage.DraftCategoryId);
   await deleteItemAsync(Storage.DraftSubcategoryName);
@@ -88,7 +89,9 @@ export async function saveDraft(draft: Draft): Promise<void> {
   await setItemAsync(Storage.DraftType, draft.type);
   await setItemAsync(Storage.DraftContent, draft.content);
   await setItemAsync(Storage.DraftRecipientId, draft.recipientId.toString());
-  if (
+  if (draft.type === MailTypes.Letter) {
+    await setItemAsync(Storage.DraftImages, JSON.stringify(draft.images));
+  } else if (
     draft.type === MailTypes.Postcard &&
     draft.design.image.uri &&
     draft.design.categoryId &&
@@ -117,10 +120,12 @@ export async function loadDraft(): Promise<Draft> {
     const draftRecipientId = await getItemAsync(Storage.DraftRecipientId);
     if (!draftType || !draftRecipientId) throw Error('No draft saved');
     if (draftType === MailTypes.Letter) {
+      const draftImages = await getItemAsync(Storage.DraftImages);
       const draft: Draft = {
         type: MailTypes.Letter,
         recipientId: parseInt(draftRecipientId, 10),
         content: draftContent || '',
+        images: draftImages ? JSON.parse(draftImages) : [],
       };
       store.dispatch(setComposing(draft));
       return draft;
@@ -154,6 +159,7 @@ export async function loadDraft(): Promise<Draft> {
       type: MailTypes.Letter,
       recipientId: -1,
       content: '',
+      images: [],
     };
     store.dispatch(setComposing(draft));
     return draft;
@@ -163,6 +169,7 @@ export async function loadDraft(): Promise<Draft> {
       type: MailTypes.Letter,
       recipientId: -1,
       content: '',
+      images: [],
     };
     store.dispatch(setComposing(draft));
     return draft;

--- a/src/components/DisplayImage/DisplayImage.react.tsx
+++ b/src/components/DisplayImage/DisplayImage.react.tsx
@@ -7,6 +7,7 @@ export interface Props {
   images: Image[];
   isPostcard?: boolean;
   heightLetter?: number;
+  paddingPostcard?: number; // additional padding to decrease width
 }
 
 const getAspectRatio = (image: Image): number => {
@@ -14,21 +15,26 @@ const getAspectRatio = (image: Image): number => {
 };
 
 const DisplayImage: React.FC<Props> = (props: Props) => {
-  const { images, isPostcard, heightLetter } = props;
+  const { images, isPostcard, heightLetter, paddingPostcard } = props;
 
   if (!images.length) return null;
 
   if (isPostcard) {
     const aspectRatio = getAspectRatio(images[0]);
+    const padding = paddingPostcard ? 2 * paddingPostcard : 0;
     return (
       <ImageComponent
         style={[
           Styles.postcardImage,
           {
             height:
-              aspectRatio > 1 ? WIDTH_POSTCARD / aspectRatio : WIDTH_POSTCARD,
+              aspectRatio > 1
+                ? (WIDTH_POSTCARD - padding) / aspectRatio
+                : WIDTH_POSTCARD,
             width:
-              aspectRatio > 1 ? WIDTH_POSTCARD : WIDTH_POSTCARD * aspectRatio,
+              aspectRatio > 1
+                ? WIDTH_POSTCARD - padding
+                : WIDTH_POSTCARD * aspectRatio,
           },
         ]}
         source={images[0]}
@@ -44,10 +50,8 @@ const DisplayImage: React.FC<Props> = (props: Props) => {
           style={[
             Styles.letterImage,
             {
-              height: heightLetter,
-              width: heightLetter
-                ? heightLetter * getAspectRatio(image)
-                : heightLetter,
+              height: heightLetter || HEIGHT_LETTER,
+              width: (heightLetter || HEIGHT_LETTER) * getAspectRatio(image),
             },
           ]}
           source={image}
@@ -60,7 +64,6 @@ const DisplayImage: React.FC<Props> = (props: Props) => {
 DisplayImage.defaultProps = {
   images: [],
   isPostcard: false,
-  heightLetter: HEIGHT_LETTER,
 };
 
 export default DisplayImage;

--- a/src/components/DisplayImage/DisplayImage.react.tsx
+++ b/src/components/DisplayImage/DisplayImage.react.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { View, Image as ImageComponent } from 'react-native';
+import { Image } from 'types';
+import Styles, { HEIGHT_LETTER, WIDTH_POSTCARD } from './DisplayImage.styles';
+
+export interface Props {
+  images: Image[];
+  isPostcard?: boolean;
+  heightLetter?: number;
+}
+
+const getAspectRatio = (image: Image): number => {
+  return image.width && image.height ? image.width / image.height : 1;
+};
+
+const DisplayImage: React.FC<Props> = (props: Props) => {
+  const { images, isPostcard, heightLetter } = props;
+
+  if (!images.length) return null;
+
+  if (isPostcard) {
+    const aspectRatio = getAspectRatio(images[0]);
+    return (
+      <ImageComponent
+        style={[
+          Styles.postcardImage,
+          {
+            height:
+              aspectRatio > 1 ? WIDTH_POSTCARD / aspectRatio : WIDTH_POSTCARD,
+            width:
+              aspectRatio > 1 ? WIDTH_POSTCARD : WIDTH_POSTCARD * aspectRatio,
+          },
+        ]}
+        source={images[0]}
+      />
+    );
+  }
+
+  return (
+    <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
+      {images.map((image) => (
+        <ImageComponent
+          key={image.uri}
+          style={[
+            Styles.letterImage,
+            {
+              height: heightLetter,
+              width: heightLetter
+                ? heightLetter * getAspectRatio(image)
+                : heightLetter,
+            },
+          ]}
+          source={image}
+        />
+      ))}
+    </View>
+  );
+};
+
+DisplayImage.defaultProps = {
+  images: [],
+  isPostcard: false,
+  heightLetter: HEIGHT_LETTER,
+};
+
+export default DisplayImage;

--- a/src/components/DisplayImage/DisplayImage.styles.tsx
+++ b/src/components/DisplayImage/DisplayImage.styles.tsx
@@ -1,0 +1,16 @@
+import { StyleSheet } from 'react-native';
+import { WINDOW_WIDTH } from '@utils';
+
+export const HEIGHT_LETTER = 225;
+export const WIDTH_POSTCARD = WINDOW_WIDTH - 40;
+
+export default StyleSheet.create({
+  postcardImage: {
+    borderRadius: 10,
+    alignSelf: 'center',
+  },
+  letterImage: {
+    borderRadius: 8,
+    margin: 4,
+  },
+});

--- a/src/components/DisplayImage/DisplayImage.styles.tsx
+++ b/src/components/DisplayImage/DisplayImage.styles.tsx
@@ -6,6 +6,7 @@ export const WIDTH_POSTCARD = WINDOW_WIDTH - 40;
 
 export default StyleSheet.create({
   postcardImage: {
+    marginVertical: 4,
     borderRadius: 10,
     alignSelf: 'center',
   },

--- a/src/components/PicUpload/PicUpload.react.tsx
+++ b/src/components/PicUpload/PicUpload.react.tsx
@@ -41,6 +41,7 @@ export interface Props {
   segmentSuccessLog?: () => void;
   segmentErrorLogEvent?: string;
   avatarPlaceholder?: boolean;
+  maintainStateImage: boolean;
 }
 
 export interface State {
@@ -57,6 +58,7 @@ class PicUpload extends React.Component<Props, State> {
     allowsEditing: true,
     initial: null,
     avatarPlaceholder: false,
+    maintainStateImage: true,
   };
 
   constructor(props: Props) {
@@ -111,18 +113,24 @@ class PicUpload extends React.Component<Props, State> {
                   height,
                 };
 
-                this.setState(
-                  {
-                    image,
-                  },
-                  () => {
-                    if (this.props.onSuccess) {
-                      this.props.onSuccess(image);
-                      if (this.props.segmentSuccessLog)
-                        this.props.segmentSuccessLog();
+                if (this.props.maintainStateImage) {
+                  this.setState(
+                    {
+                      image,
+                    },
+                    () => {
+                      if (this.props.onSuccess) {
+                        this.props.onSuccess(image);
+                        if (this.props.segmentSuccessLog)
+                          this.props.segmentSuccessLog();
+                      }
                     }
-                  }
-                );
+                  );
+                } else if (this.props.onSuccess) {
+                  this.props.onSuccess(image);
+                  if (this.props.segmentSuccessLog)
+                    this.props.segmentSuccessLog();
+                }
               }
             } catch (err) {
               if (this.props.segmentErrorLogEvent)
@@ -163,18 +171,24 @@ class PicUpload extends React.Component<Props, State> {
                   width,
                   height,
                 };
-                this.setState(
-                  {
-                    image,
-                  },
-                  () => {
-                    if (this.props.onSuccess) {
-                      this.props.onSuccess(image);
-                      if (this.props.segmentSuccessLog)
-                        this.props.segmentSuccessLog();
+                if (this.props.maintainStateImage) {
+                  this.setState(
+                    {
+                      image,
+                    },
+                    () => {
+                      if (this.props.onSuccess) {
+                        this.props.onSuccess(image);
+                        if (this.props.segmentSuccessLog)
+                          this.props.segmentSuccessLog();
+                      }
                     }
-                  }
-                );
+                  );
+                } else if (this.props.onSuccess) {
+                  this.props.onSuccess(image);
+                  if (this.props.segmentSuccessLog)
+                    this.props.segmentSuccessLog();
+                }
               }
             } catch (err) {
               if (this.props.segmentErrorLogEvent)
@@ -267,6 +281,7 @@ class PicUpload extends React.Component<Props, State> {
             this.selectImage();
             if (this.props.segmentOnPressLog) this.props.segmentOnPressLog();
           }}
+          disabled={image && image.uri.slice(-4) !== '.svg'}
           testID="clickable"
         >
           {innerCircle}

--- a/src/components/PicUpload/PicUpload.react.tsx
+++ b/src/components/PicUpload/PicUpload.react.tsx
@@ -33,7 +33,7 @@ export interface Props {
   width: number;
   height: number;
   onSuccess?: (image: Image) => void;
-  onDelete?: () => void;
+  onDelete?: (imageUri?: string) => void;
   aspect: [number, number];
   allowsEditing: boolean;
   initial: Image;
@@ -203,8 +203,9 @@ class PicUpload extends React.Component<Props, State> {
   };
 
   deleteImage = (): void => {
+    const imageUri = this.state.image?.uri;
     this.setState({ image: null }, () => {
-      if (this.props.onDelete) this.props.onDelete();
+      if (this.props.onDelete) this.props.onDelete(imageUri);
     });
   };
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,6 +8,7 @@ import CreditsCard from './Card/CreditsCard.react';
 import ComposeHeader from './ComposeHeader/ComposeHeader.react';
 import ComposeTools from './ComposeTools/ComposeTools.react';
 import DeliveryStatusCard from './Card/DeliveryStatusCard.react';
+import DisplayImage from './DisplayImage/DisplayImage.react';
 import Dropdown from './Dropdown/Dropdown.react';
 import EditablePostcard from './EditablePostcard/EditablePostcard.react';
 import GenericCard from './Card/GenericCard.react';
@@ -40,6 +41,7 @@ export {
   ComposeHeader,
   ComposeTools,
   DeliveryStatusCard,
+  DisplayImage,
   Dropdown,
   EditablePostcard,
   GenericCard,

--- a/src/store/Mail/MailActions.tsx
+++ b/src/store/Mail/MailActions.tsx
@@ -3,7 +3,7 @@ import {
   SET_COMPOSING,
   SET_RECIPIENT_ID,
   SET_CONTENT,
-  SET_IMAGE,
+  SET_IMAGES,
   SET_DESIGN,
   CLEAR_COMPOSING,
   ADD_MAIL,
@@ -37,10 +37,10 @@ export function setContent(content: string): MailActionTypes {
   };
 }
 
-export function setImage(image: Image | undefined): MailActionTypes {
+export function setImages(images: Image[]): MailActionTypes {
   return {
-    type: SET_IMAGE,
-    payload: image,
+    type: SET_IMAGES,
+    payload: images,
   };
 }
 

--- a/src/store/Mail/MailReducer.tsx
+++ b/src/store/Mail/MailReducer.tsx
@@ -22,12 +22,14 @@ const initialState: MailState = {
     type: MailTypes.Letter,
     recipientId: -1,
     content: '',
+    images: [],
   },
   active: {
     id: -1,
     type: MailTypes.Letter,
     recipientId: -1,
     content: '',
+    images: [],
     status: MailStatus.Created,
     dateCreated: new Date(),
     expectedDelivery: new Date(),
@@ -64,6 +66,7 @@ export default function LetterReducer(
         type: MailTypes.Letter,
         recipientId: -1,
         content: '',
+        images: [],
       };
       return currentState;
     case ADD_MAIL:

--- a/src/store/Mail/MailReducer.tsx
+++ b/src/store/Mail/MailReducer.tsx
@@ -3,7 +3,7 @@ import {
   SET_COMPOSING,
   SET_RECIPIENT_ID,
   SET_CONTENT,
-  SET_IMAGE,
+  SET_IMAGES,
   SET_DESIGN,
   CLEAR_COMPOSING,
   ADD_MAIL,
@@ -50,9 +50,9 @@ export default function LetterReducer(
     case SET_CONTENT:
       currentState.composing.content = action.payload;
       return currentState;
-    case SET_IMAGE:
+    case SET_IMAGES:
       if (currentState.composing.type !== MailTypes.Letter) return currentState;
-      currentState.composing.image = action.payload;
+      currentState.composing.images = action.payload;
       return currentState;
     case SET_DESIGN:
       if (currentState.composing.type !== MailTypes.Postcard)

--- a/src/store/Mail/MailTypes.tsx
+++ b/src/store/Mail/MailTypes.tsx
@@ -4,7 +4,7 @@ import { Draft, Mail, MailStatus, Image, PostcardDesign } from 'types';
 export const SET_COMPOSING = 'mail/set_composing';
 export const SET_RECIPIENT_ID = 'mail/set_recipient_id';
 export const SET_CONTENT = 'mail/set_content';
-export const SET_IMAGE = 'mail/set_image';
+export const SET_IMAGES = 'mail/set_images';
 export const SET_DESIGN = 'mail/set_design';
 export const CLEAR_COMPOSING = 'mail/clear_composing';
 
@@ -29,9 +29,9 @@ interface SetContentAction {
   payload: string;
 }
 
-interface SetImageAction {
-  type: typeof SET_IMAGE;
-  payload: Image | undefined;
+interface SetImagesAction {
+  type: typeof SET_IMAGES;
+  payload: Image[];
 }
 
 interface SetDesignAction {
@@ -107,7 +107,7 @@ export type MailActionTypes =
   | SetComposingAction
   | SetRecipientIdAction
   | SetContentAction
-  | SetImageAction
+  | SetImagesAction
   | SetDesignAction
   | ClearComposingAction
   | AddMailAction

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,8 @@ export interface PostcardDesign {
 
 interface LetterSpecific {
   type: MailTypes.Letter;
-  image?: Image;
+  images?: Image[];
+  // image: Image | undefined;
 }
 
 interface PostcardSpecific {

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export interface PostcardDesign {
 
 interface LetterSpecific {
   type: MailTypes.Letter;
-  images?: Image[]; // TODO make not optional
+  images: Image[];
 }
 
 interface PostcardSpecific {
@@ -171,6 +171,7 @@ export enum Storage {
   DraftType = 'Ameelio-DraftType',
   DraftContent = 'Ameelio-DraftContent',
   DraftRecipientId = 'Ameelio-DraftRecipientId',
+  DraftImages = 'Ameelio-DraftImages',
   DraftCategoryId = 'Ameelio-DraftCategoryId',
   DraftSubcategoryName = 'Ameelio-DraftSubcategoryName',
   DraftDesignUri = 'Ameelio-DraftDesignUri',

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,8 +24,7 @@ export interface PostcardDesign {
 
 interface LetterSpecific {
   type: MailTypes.Letter;
-  images?: Image[];
-  // image: Image | undefined;
+  images?: Image[]; // TODO make not optional
 }
 
 interface PostcardSpecific {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
-import { Dimensions, Share } from 'react-native';
+import { Dimensions, Share, Image as ImageComponent } from 'react-native';
 import * as EmailValidator from 'email-validator';
 import PhoneNumber from 'awesome-phonenumber';
 import * as ImagePicker from 'expo-image-picker';
@@ -301,3 +301,17 @@ export const onNativeShare = async (
     });
   }
 };
+
+export function getImageDims(
+  uri: string
+): Promise<{ width: number; height: number }> {
+  return new Promise((res, rej) => {
+    ImageComponent.getSize(
+      uri,
+      (width, height) => {
+        res({ width, height });
+      },
+      rej
+    );
+  });
+}

--- a/src/views/Compose/ChooseOption.react.tsx
+++ b/src/views/Compose/ChooseOption.react.tsx
@@ -79,6 +79,7 @@ const ChooseOptionScreenBase: React.FC<Props> = (props: Props) => {
             type: MailTypes.Letter,
             recipientId: props.recipientId,
             content: '',
+            images: [],
           });
           props.navigation.navigate(Screens.ComposeLetter);
         }}

--- a/src/views/Compose/Compose.styles.tsx
+++ b/src/views/Compose/Compose.styles.tsx
@@ -2,7 +2,6 @@ import { StyleSheet } from 'react-native';
 import { WINDOW_WIDTH, WINDOW_HEIGHT } from '@utils';
 
 export const LETTER_COMPOSE_IMAGE_HEIGHT = 150;
-export const LETTER_REVIEW_IMAGE_HEIGHT = 225;
 
 export default StyleSheet.create({
   screenBackground: {

--- a/src/views/Compose/Compose.styles.tsx
+++ b/src/views/Compose/Compose.styles.tsx
@@ -1,6 +1,9 @@
 import { StyleSheet } from 'react-native';
 import { WINDOW_WIDTH, WINDOW_HEIGHT } from '@utils';
 
+export const LETTER_COMPOSE_IMAGE_HEIGHT = 150;
+export const LETTER_REVIEW_IMAGE_HEIGHT = 225;
+
 export default StyleSheet.create({
   screenBackground: {
     padding: 16,
@@ -55,5 +58,4 @@ export default StyleSheet.create({
     paddingHorizontal: 4,
     paddingBottom: 26,
   },
-  gridDesignBackground: {},
 });

--- a/src/views/Compose/ComposeLetter.react.tsx
+++ b/src/views/Compose/ComposeLetter.react.tsx
@@ -199,6 +199,7 @@ class ComposeLetterScreenBase extends React.Component<Props, State> {
       }),
       () => {
         this.props.setImages(this.state.images);
+        saveDraft(this.props.composing);
       }
     );
     Keyboard.dismiss();

--- a/src/views/Compose/ComposeLetter.react.tsx
+++ b/src/views/Compose/ComposeLetter.react.tsx
@@ -28,7 +28,6 @@ import { setProfileOverride } from '@components/Topbar/Topbar.react';
 import { popupAlert } from '@components/Alert/Alert.react';
 import * as Segment from 'expo-analytics-segment';
 import { saveDraft } from '@api';
-import { Colors } from '@styles';
 import Styles, { LETTER_COMPOSE_IMAGE_HEIGHT } from './Compose.styles';
 
 type ComposeLetterScreenNavigationProp = StackNavigationProp<

--- a/src/views/Compose/ComposeLetter.react.tsx
+++ b/src/views/Compose/ComposeLetter.react.tsx
@@ -53,7 +53,7 @@ interface Props {
   setImages: (images: Image[]) => void;
 }
 
-const MAX_NUM_IMAGES = 4;
+const MAX_NUM_IMAGES = 2;
 
 class ComposeLetterScreenBase extends React.Component<Props, State> {
   private textRef = createRef<TextInput>();

--- a/src/views/Compose/ReviewLetter.react.tsx
+++ b/src/views/Compose/ReviewLetter.react.tsx
@@ -1,6 +1,6 @@
 import React, { Dispatch } from 'react';
-import { View, Text, ScrollView, Image } from 'react-native';
-import { GrayBar } from '@components';
+import { View, Text, ScrollView } from 'react-native';
+import { GrayBar, DisplayImage } from '@components';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { AppStackParamList, Screens } from '@utils/Screens';
 import { connect } from 'react-redux';
@@ -15,7 +15,7 @@ import { MailActionTypes } from '@store/Mail/MailTypes';
 import { cleanupAfterSend } from '@utils/Notifications';
 import * as Segment from 'expo-analytics-segment';
 import { setProfileOverride } from '@components/Topbar/Topbar.react';
-import Styles, { LETTER_REVIEW_IMAGE_HEIGHT } from './Compose.styles';
+import Styles from './Compose.styles';
 
 type ReviewLetterScreenNavigationProp = StackNavigationProp<
   AppStackParamList,
@@ -139,27 +139,9 @@ class ReviewLetterScreenBase extends React.Component<Props> {
             >
               {this.props.composing.content}
             </Text>
-            <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
-              {this.props.composing.images?.map((image) => {
-                const aspect =
-                  image && image.width && image.height
-                    ? image.width / image.height
-                    : 1;
-                return (
-                  <Image
-                    key={image.uri}
-                    source={image}
-                    style={{
-                      height: LETTER_REVIEW_IMAGE_HEIGHT,
-                      width: LETTER_REVIEW_IMAGE_HEIGHT * aspect,
-                      aspectRatio: aspect,
-                      borderRadius: 8,
-                      margin: 4,
-                    }}
-                  />
-                );
-              })}
-            </View>
+            {this.props.composing.images && (
+              <DisplayImage images={this.props.composing.images} />
+            )}
           </ScrollView>
         </View>
         <Text

--- a/src/views/Compose/ReviewLetter.react.tsx
+++ b/src/views/Compose/ReviewLetter.react.tsx
@@ -15,7 +15,7 @@ import { MailActionTypes } from '@store/Mail/MailTypes';
 import { cleanupAfterSend } from '@utils/Notifications';
 import * as Segment from 'expo-analytics-segment';
 import { setProfileOverride } from '@components/Topbar/Topbar.react';
-import Styles from './Compose.styles';
+import Styles, { LETTER_REVIEW_IMAGE_HEIGHT } from './Compose.styles';
 
 type ReviewLetterScreenNavigationProp = StackNavigationProp<
   AppStackParamList,
@@ -122,19 +122,7 @@ class ReviewLetterScreenBase extends React.Component<Props> {
       this.props.navigation.goBack();
       return null;
     }
-    const { images } = this.props.composing;
-    let image;
-    if (images?.length === 1) [image] = images;
 
-    let width = 275;
-    let height = 275;
-    if (image && image.width && image.height) {
-      if (image.width > image.height) {
-        height = (image.height / image.width) * width;
-      } else {
-        width = (image.width / image.height) * height;
-      }
-    }
     return (
       <View style={Styles.screenBackground}>
         <View style={{ flex: 1 }}>
@@ -151,21 +139,26 @@ class ReviewLetterScreenBase extends React.Component<Props> {
             >
               {this.props.composing.content}
             </Text>
-            <View style={{ flex: 1 }}>
-              {this.props.composing.images?.length && (
-                <Image
-                  source={this.props.composing.images[0]}
-                  style={{
-                    height,
-                    width,
-                    borderRadius: 10,
-                    aspectRatio:
-                      image && image.width && image.height
-                        ? image.width / image.height
-                        : 1,
-                  }}
-                />
-              )}
+            <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
+              {this.props.composing.images?.map((image) => {
+                const aspect =
+                  image && image.width && image.height
+                    ? image.width / image.height
+                    : 1;
+                return (
+                  <Image
+                    key={image.uri}
+                    source={image}
+                    style={{
+                      height: LETTER_REVIEW_IMAGE_HEIGHT,
+                      width: LETTER_REVIEW_IMAGE_HEIGHT * aspect,
+                      aspectRatio: aspect,
+                      borderRadius: 8,
+                      margin: 4,
+                    }}
+                  />
+                );
+              })}
             </View>
           </ScrollView>
         </View>

--- a/src/views/Compose/ReviewLetter.react.tsx
+++ b/src/views/Compose/ReviewLetter.react.tsx
@@ -122,7 +122,10 @@ class ReviewLetterScreenBase extends React.Component<Props> {
       this.props.navigation.goBack();
       return null;
     }
-    const { image } = this.props.composing;
+    const { images } = this.props.composing;
+    let image;
+    if (images?.length === 1) [image] = images;
+
     let width = 275;
     let height = 275;
     if (image && image.width && image.height) {
@@ -149,9 +152,9 @@ class ReviewLetterScreenBase extends React.Component<Props> {
               {this.props.composing.content}
             </Text>
             <View style={{ flex: 1 }}>
-              {this.props.composing.image && (
+              {this.props.composing.images?.length && (
                 <Image
-                  source={this.props.composing.image}
+                  source={this.props.composing.images[0]}
                   style={{
                     height,
                     width,

--- a/src/views/Compose/ReviewLetter.react.tsx
+++ b/src/views/Compose/ReviewLetter.react.tsx
@@ -139,9 +139,7 @@ class ReviewLetterScreenBase extends React.Component<Props> {
             >
               {this.props.composing.content}
             </Text>
-            {this.props.composing.images && (
-              <DisplayImage images={this.props.composing.images} />
-            )}
+            <DisplayImage images={this.props.composing.images} />
           </ScrollView>
         </View>
         <Text

--- a/src/views/Home/MailTracking.react.tsx
+++ b/src/views/Home/MailTracking.react.tsx
@@ -343,7 +343,7 @@ class MailTrackingScreenBase extends React.Component<Props, State> {
             {i18n.t('MailTrackingScreen.letterContent')}
           </Text>
           <Text style={{ fontSize: 15 }}>{mail.content}</Text>
-          {mail.type === MailTypes.Letter && mail.images?.length && (
+          {mail.type === MailTypes.Letter && (
             <DisplayImage images={mail.images} heightLetter={160} />
           )}
           {mail.type === MailTypes.Postcard && (

--- a/src/views/Home/MailTracking.react.tsx
+++ b/src/views/Home/MailTracking.react.tsx
@@ -2,7 +2,14 @@ import React, { Dispatch } from 'react';
 import { Linking, Text, ScrollView, View, Image, Animated } from 'react-native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { AppStackParamList, Screens } from '@utils/Screens';
-import { Button, LetterTracker, GrayBar, Icon, ProfilePic } from '@components';
+import {
+  Button,
+  LetterTracker,
+  GrayBar,
+  Icon,
+  ProfilePic,
+  DisplayImage,
+} from '@components';
 import { connect } from 'react-redux';
 import { Colors, Typography } from '@styles';
 import { AppState } from '@store/types';
@@ -336,42 +343,11 @@ class MailTrackingScreenBase extends React.Component<Props, State> {
             {i18n.t('MailTrackingScreen.letterContent')}
           </Text>
           <Text style={{ fontSize: 15 }}>{mail.content}</Text>
-          {mail.type === MailTypes.Letter &&
-            mail.images?.length &&
-            mail.images.map((image) => (
-              <Image
-                key={image.uri}
-                style={[
-                  Styles.trackingPhoto,
-                  {
-                    margin: 4,
-                    height: 275,
-                    width:
-                      image.width && image.height
-                        ? (image.width / image.height) * 275
-                        : 275,
-                  },
-                ]}
-                source={image}
-                testID="memoryLaneImage"
-              />
-            ))}
+          {mail.type === MailTypes.Letter && mail.images?.length && (
+            <DisplayImage images={mail.images} heightLetter={160} />
+          )}
           {mail.type === MailTypes.Postcard && (
-            <Image
-              style={[
-                Styles.trackingPhoto,
-                {
-                  height: 275,
-                  width:
-                    mail.design.image.width && mail.design.image.height
-                      ? (mail.design.image.width / mail.design.image.height) *
-                        275
-                      : 275,
-                },
-              ]}
-              source={mail.design.image}
-              testID="memoryLaneImage"
-            />
+            <DisplayImage images={[mail.design.image]} isPostcard />
           )}
           <View style={{ height: 40 }} />
         </View>

--- a/src/views/Home/MailTracking.react.tsx
+++ b/src/views/Home/MailTracking.react.tsx
@@ -1,5 +1,5 @@
 import React, { Dispatch } from 'react';
-import { Linking, Text, ScrollView, View, Image, Animated } from 'react-native';
+import { Linking, Text, ScrollView, View, Animated } from 'react-native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { AppStackParamList, Screens } from '@utils/Screens';
 import {
@@ -347,7 +347,11 @@ class MailTrackingScreenBase extends React.Component<Props, State> {
             <DisplayImage images={mail.images} heightLetter={160} />
           )}
           {mail.type === MailTypes.Postcard && (
-            <DisplayImage images={[mail.design.image]} isPostcard />
+            <DisplayImage
+              images={[mail.design.image]}
+              isPostcard
+              paddingPostcard={20}
+            />
           )}
           <View style={{ height: 40 }} />
         </View>

--- a/src/views/Home/MailTracking.react.tsx
+++ b/src/views/Home/MailTracking.react.tsx
@@ -336,19 +336,19 @@ class MailTrackingScreenBase extends React.Component<Props, State> {
             {i18n.t('MailTrackingScreen.letterContent')}
           </Text>
           <Text style={{ fontSize: 15 }}>{mail.content}</Text>
-          {mail.type === MailTypes.Letter && mail.image?.uri ? (
+          {mail.type === MailTypes.Letter && mail.images?.length ? (
             <Image
               style={[
                 Styles.trackingPhoto,
                 {
                   height: 275,
                   width:
-                    mail.image.width && mail.image.height
-                      ? (mail.image.width / mail.image.height) * 275
+                    mail.images[0].width && mail.images[0].height
+                      ? (mail.images[0].width / mail.images[0].height) * 275
                       : 275,
                 },
               ]}
-              source={mail.image}
+              source={mail.images[0]}
               testID="memoryLaneImage"
             />
           ) : null}

--- a/src/views/Home/MailTracking.react.tsx
+++ b/src/views/Home/MailTracking.react.tsx
@@ -336,22 +336,26 @@ class MailTrackingScreenBase extends React.Component<Props, State> {
             {i18n.t('MailTrackingScreen.letterContent')}
           </Text>
           <Text style={{ fontSize: 15 }}>{mail.content}</Text>
-          {mail.type === MailTypes.Letter && mail.images?.length ? (
-            <Image
-              style={[
-                Styles.trackingPhoto,
-                {
-                  height: 275,
-                  width:
-                    mail.images[0].width && mail.images[0].height
-                      ? (mail.images[0].width / mail.images[0].height) * 275
-                      : 275,
-                },
-              ]}
-              source={mail.images[0]}
-              testID="memoryLaneImage"
-            />
-          ) : null}
+          {mail.type === MailTypes.Letter &&
+            mail.images?.length &&
+            mail.images.map((image) => (
+              <Image
+                key={image.uri}
+                style={[
+                  Styles.trackingPhoto,
+                  {
+                    margin: 4,
+                    height: 275,
+                    width:
+                      image.width && image.height
+                        ? (image.width / image.height) * 275
+                        : 275,
+                  },
+                ]}
+                source={image}
+                testID="memoryLaneImage"
+              />
+            ))}
           {mail.type === MailTypes.Postcard && (
             <Image
               style={[

--- a/src/views/Home/MailTracking.styles.tsx
+++ b/src/views/Home/MailTracking.styles.tsx
@@ -44,14 +44,6 @@ export default StyleSheet.create({
     color: Colors.AMEELIO_BLACK,
     fontSize: 14,
   },
-  trackingPhoto: {
-    height: 275,
-    width: '100%',
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderRadius: 10,
-    aspectRatio: 1,
-  },
   animatedTruck: {
     borderRadius: 50,
     backgroundColor: Colors.BLUE_500,

--- a/src/views/Home/SingleContact.react.tsx
+++ b/src/views/Home/SingleContact.react.tsx
@@ -278,7 +278,7 @@ class SingleContactScreenBase extends React.Component<Props, State> {
                     Type:
                       this.props.composing.content.length ||
                       (this.props.composing.type === MailTypes.Letter &&
-                        this.props.composing.image) ||
+                        this.props.composing.images?.length) ||
                       this.props.composing.type === MailTypes.Postcard
                         ? 'draft'
                         : 'blank',
@@ -287,7 +287,7 @@ class SingleContactScreenBase extends React.Component<Props, State> {
                 if (
                   this.props.composing.content.length ||
                   (this.props.composing.type === MailTypes.Letter &&
-                    this.props.composing.image) ||
+                    this.props.composing.images?.length) ||
                   (this.props.composing.type === MailTypes.Postcard &&
                     this.props.composing.design.image.uri.length)
                 ) {

--- a/src/views/Home/SingleContact.react.tsx
+++ b/src/views/Home/SingleContact.react.tsx
@@ -278,7 +278,7 @@ class SingleContactScreenBase extends React.Component<Props, State> {
                     Type:
                       this.props.composing.content.length ||
                       (this.props.composing.type === MailTypes.Letter &&
-                        this.props.composing.images?.length) ||
+                        this.props.composing.images.length) ||
                       this.props.composing.type === MailTypes.Postcard
                         ? 'draft'
                         : 'blank',
@@ -287,7 +287,7 @@ class SingleContactScreenBase extends React.Component<Props, State> {
                 if (
                   this.props.composing.content.length ||
                   (this.props.composing.type === MailTypes.Letter &&
-                    this.props.composing.images?.length) ||
+                    this.props.composing.images.length) ||
                   (this.props.composing.type === MailTypes.Postcard &&
                     this.props.composing.design.image.uri.length)
                 ) {
@@ -368,6 +368,7 @@ class SingleContactScreenBase extends React.Component<Props, State> {
                             type: MailTypes.Letter,
                             recipientId: this.props.activeContact.id,
                             content: '',
+                            images: [],
                           });
                           this.props.navigation.navigate(
                             Screens.ChooseCategory
@@ -382,6 +383,7 @@ class SingleContactScreenBase extends React.Component<Props, State> {
                     type: MailTypes.Letter,
                     recipientId: this.props.activeContact.id,
                     content: '',
+                    images: [],
                   });
                   this.props.navigation.navigate(Screens.ChooseCategory);
                 }

--- a/src/views/MemoryLane/MailDetails.react.tsx
+++ b/src/views/MemoryLane/MailDetails.react.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ScrollView, Text, View, Image } from 'react-native';
+import { ScrollView, Text, View } from 'react-native';
 import { AppStackParamList } from '@utils/Screens';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { Mail, MailTypes, MailStatus } from 'types';
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import { AppState } from '@store/types';
 import { format } from 'date-fns';
 import { Typography } from '@styles';
+import { DisplayImage } from '@components';
 import Styles from './MailDetails.styles';
 
 type MailDetailsScreenNavigationProp = StackNavigationProp<
@@ -25,25 +26,7 @@ const MailDetailsScreenBase: React.FC<Props> = (props: Props) => {
     mail.dateCreated ? mail.dateCreated : new Date(),
     'MMM dd, yyyy'
   );
-  let images = null;
-  if (mail.type === MailTypes.Letter && mail.images?.length) {
-    images = mail.images.map((image) => (
-      <Image
-        key={image.uri}
-        style={Styles.memoryLaneLetterImages}
-        source={image}
-        testID="memoryLaneImage"
-      />
-    ));
-  } else if (mail.type === MailTypes.Postcard) {
-    images = (
-      <Image
-        style={Styles.memoryLanePicture}
-        source={mail.design.image}
-        testID="memoryLaneImage"
-      />
-    );
-  }
+
   return (
     <View
       style={[
@@ -60,7 +43,12 @@ const MailDetailsScreenBase: React.FC<Props> = (props: Props) => {
         <Text style={[Typography.FONT_REGULAR, Styles.letterText]}>
           {mail.content}
         </Text>
-        {images}
+        {mail.type === MailTypes.Letter && mail.images && (
+          <DisplayImage images={mail.images} />
+        )}
+        {mail.type === MailTypes.Postcard && (
+          <DisplayImage images={[mail.design.image]} isPostcard />
+        )}
       </ScrollView>
     </View>
   );

--- a/src/views/MemoryLane/MailDetails.react.tsx
+++ b/src/views/MemoryLane/MailDetails.react.tsx
@@ -47,7 +47,11 @@ const MailDetailsScreenBase: React.FC<Props> = (props: Props) => {
           <DisplayImage images={mail.images} />
         )}
         {mail.type === MailTypes.Postcard && (
-          <DisplayImage images={[mail.design.image]} isPostcard />
+          <DisplayImage
+            images={[mail.design.image]}
+            isPostcard
+            paddingPostcard={5}
+          />
         )}
       </ScrollView>
     </View>

--- a/src/views/MemoryLane/MailDetails.react.tsx
+++ b/src/views/MemoryLane/MailDetails.react.tsx
@@ -25,17 +25,18 @@ const MailDetailsScreenBase: React.FC<Props> = (props: Props) => {
     mail.dateCreated ? mail.dateCreated : new Date(),
     'MMM dd, yyyy'
   );
-  let image = null;
+  let images = null;
   if (mail.type === MailTypes.Letter && mail.images?.length) {
-    image = (
+    images = mail.images.map((image) => (
       <Image
-        style={Styles.memoryLanePicture}
-        source={mail.images[0]}
+        key={image.uri}
+        style={Styles.memoryLaneLetterImages}
+        source={image}
         testID="memoryLaneImage"
       />
-    );
+    ));
   } else if (mail.type === MailTypes.Postcard) {
-    image = (
+    images = (
       <Image
         style={Styles.memoryLanePicture}
         source={mail.design.image}
@@ -59,7 +60,7 @@ const MailDetailsScreenBase: React.FC<Props> = (props: Props) => {
         <Text style={[Typography.FONT_REGULAR, Styles.letterText]}>
           {mail.content}
         </Text>
-        {image}
+        {images}
       </ScrollView>
     </View>
   );

--- a/src/views/MemoryLane/MailDetails.react.tsx
+++ b/src/views/MemoryLane/MailDetails.react.tsx
@@ -43,7 +43,7 @@ const MailDetailsScreenBase: React.FC<Props> = (props: Props) => {
         <Text style={[Typography.FONT_REGULAR, Styles.letterText]}>
           {mail.content}
         </Text>
-        {mail.type === MailTypes.Letter && mail.images && (
+        {mail.type === MailTypes.Letter && (
           <DisplayImage images={mail.images} />
         )}
         {mail.type === MailTypes.Postcard && (
@@ -62,6 +62,7 @@ const blankMail: Mail = {
   dateCreated: new Date(),
   expectedDelivery: new Date(),
   content: '',
+  images: [],
 };
 
 const mapStateToProps = (state: AppState) => ({

--- a/src/views/MemoryLane/MailDetails.react.tsx
+++ b/src/views/MemoryLane/MailDetails.react.tsx
@@ -26,11 +26,11 @@ const MailDetailsScreenBase: React.FC<Props> = (props: Props) => {
     'MMM dd, yyyy'
   );
   let image = null;
-  if (mail.type === MailTypes.Letter && mail.image) {
+  if (mail.type === MailTypes.Letter && mail.images?.length) {
     image = (
       <Image
         style={Styles.memoryLanePicture}
-        source={mail.image}
+        source={mail.images[0]}
         testID="memoryLaneImage"
       />
     );

--- a/src/views/MemoryLane/MailDetails.styles.tsx
+++ b/src/views/MemoryLane/MailDetails.styles.tsx
@@ -23,18 +23,4 @@ export default StyleSheet.create({
     paddingTop: 16,
     paddingBottom: 36,
   },
-  memoryLanePicture: {
-    height: 275,
-    width: '100%',
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderRadius: 10,
-    aspectRatio: 1,
-  },
-  memoryLaneLetterImages: {
-    height: 225,
-    borderRadius: 8,
-    margin: 4,
-    aspectRatio: 1,
-  },
 });

--- a/src/views/MemoryLane/MailDetails.styles.tsx
+++ b/src/views/MemoryLane/MailDetails.styles.tsx
@@ -31,4 +31,10 @@ export default StyleSheet.create({
     borderRadius: 10,
     aspectRatio: 1,
   },
+  memoryLaneLetterImages: {
+    height: 225,
+    borderRadius: 8,
+    margin: 4,
+    aspectRatio: 1,
+  },
 });

--- a/src/views/MemoryLane/MemoryLane.react.tsx
+++ b/src/views/MemoryLane/MemoryLane.react.tsx
@@ -30,8 +30,8 @@ const MemoryLaneScreenBase: React.FC<Props> = (props: Props) => {
     mail && mail.length > 0 ? (
       mail.map((item: Mail) => {
         let imageUri = '';
-        if (item.type === MailTypes.Letter && item.image)
-          imageUri = item.image.uri;
+        if (item.type === MailTypes.Letter && item.images?.length)
+          imageUri = item.images[0].uri;
         else if (item.type === MailTypes.Postcard)
           imageUri = item.design.image.uri;
         return (

--- a/src/views/MemoryLane/MemoryLane.react.tsx
+++ b/src/views/MemoryLane/MemoryLane.react.tsx
@@ -30,7 +30,7 @@ const MemoryLaneScreenBase: React.FC<Props> = (props: Props) => {
     mail && mail.length > 0 ? (
       mail.map((item: Mail) => {
         let imageUri = '';
-        if (item.type === MailTypes.Letter && item.images?.length)
+        if (item.type === MailTypes.Letter && item.images.length)
           imageUri = item.images[0].uri;
         else if (item.type === MailTypes.Postcard)
           imageUri = item.design.image.uri;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
now you can upload multiple images to letter!

## Description
<!--- Describe your changes in detail -->
- ComposeLetter maintains `images` in `state` (instead of `PicUpload` storing the image). ComposeLetter also maintains `text` in `state` to make formatting easier
- fixed rendering of image dimensions on a few screens using `DisplayImage`
- storing/uploading/fetching multiple images now supported

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
part of #285 

TODO: did not update Letter Preview screen to use page-like layout

## Screenshots (if appropriate):
https://drive.google.com/file/d/15YgCW86fur2CwbC5dhW2kiwzqKDW8QhE/view?usp=sharing
