### PR TITLE
[Compose] Better loading feedback on stickers

### DIFF
--- a/src/assets/stickers/index.tsx
+++ b/src/assets/stickers/index.tsx
@@ -35,69 +35,45 @@ const HappyBirthdayComponent = (
   />
 );
 
-const HeartsComponent = (
-  <ImageComponent source={Hearts} style={{ width: '100%', height: '100%' }} />
-);
-
-const LoveYouComponent = (
-  <ImageComponent source={LoveYou} style={{ width: '100%', height: '100%' }} />
-);
-
-const MissYouComponent = (
-  <ImageComponent source={MissYou} style={{ width: '100%', height: '100%' }} />
-);
-
-const StarsComponent = (
-  <ImageComponent source={Stars} style={{ width: '100%', height: '100%' }} />
-);
-
-const SunshineComponent = (
-  <ImageComponent source={Sunshine} style={{ width: '100%', height: '100%' }} />
-);
-
-const TwoPeasComponent = (
-  <ImageComponent source={TwoPeas} style={{ width: '100%', height: '100%' }} />
-);
-
 const STICKERS: Sticker[] = [
   {
-    component: AmeelioComponent,
+    image: Ameelio,
     name: 'Sent by Ameelio',
   },
   {
-    component: BestDadComponent,
+    image: BestDad,
     name: '#1 Dad',
   },
   {
-    component: EggcelentComponent,
+    image: Eggcelent,
     name: 'Eggcelent',
   },
   {
-    component: HappyBirthdayComponent,
+    image: HappyBirthday,
     name: 'Happy Birthday',
   },
   {
-    component: HeartsComponent,
+    image: Hearts,
     name: 'Hearts',
   },
   {
-    component: LoveYouComponent,
+    image: LoveYou,
     name: 'Love You',
   },
   {
-    component: MissYouComponent,
+    image: MissYou,
     name: 'Miss You',
   },
   {
-    component: StarsComponent,
+    image: Stars,
     name: 'Stars',
   },
   {
-    component: SunshineComponent,
+    image: Sunshine,
     name: 'Sunshine',
   },
   {
-    component: TwoPeasComponent,
+    image: TwoPeas,
     name: 'Two Peas',
   },
 ];

--- a/src/components/AsyncImage/AsyncImage.react.tsx
+++ b/src/components/AsyncImage/AsyncImage.react.tsx
@@ -63,18 +63,18 @@ class AsyncImage extends React.Component<Props, State> {
       imageWidth: 200,
       imageHeight: 200,
     };
-    this.loadImage = this.loadImage.bind(this);
+    this.loadRemoteImage = this.loadRemoteImage.bind(this);
   }
 
   async componentDidMount(): Promise<void> {
     this.testTimeout();
-    if (!this.props.local) await this.loadImage();
+    if (!this.props.local) await this.loadRemoteImage();
   }
 
   componentDidUpdate(prevProps: Props): void {
     if (this.props.local) return;
     if (prevProps.source.uri === this.props.source.uri) return;
-    this.loadImage();
+    this.loadRemoteImage();
   }
 
   testTimeout = async (): Promise<void> => {
@@ -127,7 +127,8 @@ class AsyncImage extends React.Component<Props, State> {
     }).start();
   }
 
-  async loadImage(): Promise<void> {
+  async loadRemoteImage(): Promise<void> {
+    if (this.props.local) return;
     this.setState({
       loaded: false,
       timedOut: false,
@@ -267,7 +268,7 @@ class AsyncImage extends React.Component<Props, State> {
                 timedOut: false,
               });
               this.testTimeout();
-              if (!this.props.local) await this.loadImage();
+              if (!this.props.local) await this.loadRemoteImage();
             }}
           >
             <ImageComponent
@@ -303,8 +304,8 @@ class AsyncImage extends React.Component<Props, State> {
           });
         }}
       >
-        {(!!this.props.source.uri || this.props.local) &&
-          (!!this.state.imgURI || this.props.local) &&
+        {(this.props.local ||
+          (!!this.props.source.uri && !!this.state.imgURI)) &&
           renderedImage}
         {asyncFeedback}
       </View>

--- a/src/components/DynamicPostcard/DynamicPostcard.react.tsx
+++ b/src/components/DynamicPostcard/DynamicPostcard.react.tsx
@@ -1,5 +1,11 @@
 import React, { createRef } from 'react';
-import { View, Animated, TouchableOpacity, PixelRatio } from 'react-native';
+import {
+  View,
+  Animated,
+  TouchableOpacity,
+  PixelRatio,
+  Image as ImageComponent,
+} from 'react-native';
 import {
   Contact,
   Image,
@@ -233,7 +239,10 @@ class DynamicPostcard extends React.Component<Props> {
                     }}
                     key={placedSticker.id}
                   >
-                    {placedSticker.sticker.component}
+                    <ImageComponent
+                      source={placedSticker.sticker.image}
+                      style={{ width: '100%', height: '100%' }}
+                    />
                   </View>
                 );
               })}

--- a/src/components/StickerManager/StickerComponent.react.tsx
+++ b/src/components/StickerManager/StickerComponent.react.tsx
@@ -1,6 +1,11 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React, { createRef } from 'react';
-import { PanResponderInstance, Animated, PanResponder } from 'react-native';
+import {
+  PanResponderInstance,
+  Animated,
+  PanResponder,
+  Image as ImageComponent,
+} from 'react-native';
 import { Sticker } from 'types';
 import {
   PinchGestureHandler,
@@ -146,7 +151,10 @@ export default class StickerComponent extends React.Component<Props> {
               }}
               {...this.panResponder.panHandlers}
             >
-              {this.props.sticker.component}
+              <ImageComponent
+                source={this.props.sticker.image}
+                style={{ width: '100%', height: '100%' }}
+              />
             </Animated.View>
           </Animated.View>
         </PinchGestureHandler>

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,8 +6,8 @@ export interface Image {
 }
 
 export interface Sticker {
-  component: JSX.Element;
   name: string;
+  image: Image;
 }
 
 export interface PlacedSticker {

--- a/src/views/Compose/ComposePersonal.react.tsx
+++ b/src/views/Compose/ComposePersonal.react.tsx
@@ -631,7 +631,14 @@ class ComposePersonalScreenBase extends React.Component<Props, State> {
           this.closeBottom();
         }}
       >
-        {sticker.component}
+        <AsyncImage
+          source={sticker.image}
+          imageStyle={{ width: '100%', height: '100%', resizeMode: 'contain' }}
+          download={false}
+          local
+          autorotate={false}
+          loadingBackgroundColor="rgba(0,0,0,0)"
+        />
       </TouchableOpacity>
     );
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changed how local assets for stickers are stored to reduce loading time. Added support to async image for local assets, and transitioned to using async image to display stickers to show proper loading feedback.

## Description
<!--- Describe your changes in detail -->
Moved storage of sticker assets fom eporting a "prerendered" component to exporting the raw source, which can be more effectively loaded and cached by built in Image Component. Added support to AsyncImage for local assets, to reuse loading logic / designs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Better feedback to users about the app's loading status
Closes #366 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Pixel emulator.

## Screenshots (if appropriate):
https://drive.google.com/file/d/1g-gfL98dpCT0roMRrH_V0s9x8lIhhur0/view?usp=sharing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
