### PR TITLE
[Optimization] Call getImageDims more smartly

### DIFF
--- a/src/api/Mail.ts
+++ b/src/api/Mail.ts
@@ -116,19 +116,11 @@ async function cleanMail(mail: RawMail): Promise<Mail> {
   const recipientId = mail.contact_id;
   let images: Image[] = [];
   if (mail.images.length) {
-    try {
-      images = await Promise.all(
-        mail.images.map(async (rawImage) => {
-          const dimensions = await getImageDims(rawImage.img_src);
-          return {
-            uri: rawImage.img_src,
-            ...dimensions,
-          };
-        })
-      );
-    } catch {
-      images = mail.images.map((rawImage) => ({ uri: rawImage.img_src }));
-    }
+    images = mail.images.map((rawImage) => {
+      return {
+        uri: rawImage.img_src,
+      };
+    });
   }
   const design = { image: images.length ? images[0] : { uri: '' } };
 
@@ -203,19 +195,7 @@ async function cleanMassMail(mail: RawMail): Promise<Mail> {
   const recipientId = mail.contact_id;
   let images: Image[] = [];
   if (mail.images.length) {
-    try {
-      images = await Promise.all(
-        mail.images.map(async (rawImage) => {
-          const dimensions = await getImageDims(rawImage.img_src);
-          return {
-            uri: rawImage.img_src,
-            ...dimensions,
-          };
-        })
-      );
-    } catch {
-      images = mail.images.map((rawImage) => ({ uri: rawImage.img_src }));
-    }
+    images = mail.images.map((rawImage) => ({ uri: rawImage.img_src }));
   }
   const design = { image: images.length ? images[0] : { uri: '' } };
   const dateCreated = new Date(mail.created_at).toISOString();
@@ -501,14 +481,11 @@ async function cleanDesign(
   subcategoryName?: string
 ): Promise<PostcardDesign> {
   try {
-    const imageDims = await getImageDims(raw.front_img_src);
-    const thumbnailDims = await getImageDims(raw.thumbnail_src);
     return {
       image: {
         uri: raw.front_img_src,
-        ...imageDims,
       },
-      thumbnail: { uri: raw.thumbnail_src, ...thumbnailDims },
+      thumbnail: { uri: raw.thumbnail_src },
       name: raw.name,
       id: raw.id,
       categoryId,

--- a/src/components/AsyncImage/AsyncImage.react.tsx
+++ b/src/components/AsyncImage/AsyncImage.react.tsx
@@ -16,8 +16,8 @@ import { TouchableOpacity } from 'react-native-gesture-handler';
 
 interface Props {
   source: Image;
-  viewStyle?: ViewStyle;
-  imageStyle?: ImageStyle;
+  viewStyle?: ViewStyle | ViewStyle[];
+  imageStyle?: ImageStyle | ImageStyle[];
   loadingSize?: number;
   timeout: number;
   download?: boolean;

--- a/src/components/Card/ContactSelectorCard.react.tsx
+++ b/src/components/Card/ContactSelectorCard.react.tsx
@@ -127,7 +127,8 @@ const ContactSelectorCard: React.FC<Props> = (props: Props) => {
                 : i18n.t('ContactSelectorScreen.letters')}
             </AdjustableText>
             {lettersTravelled > 0 && (
-              <Text
+              <AdjustableText
+                numberOfLines={1}
                 style={[
                   Typography.FONT_REGULAR,
                   { paddingBottom: 4, color: Colors.GRAY_500 },
@@ -136,7 +137,7 @@ const ContactSelectorCard: React.FC<Props> = (props: Props) => {
                 <Emoji name="airplane" />{' '}
                 {i18n.t('SingleContactScreen.lettersTraveled')}:{' '}
                 {lettersTravelled} {i18n.t('ContactSelectorScreen.miles')}
-              </Text>
+              </AdjustableText>
             )}
           </View>
         )}

--- a/src/components/DisplayImage/DisplayImage.react.tsx
+++ b/src/components/DisplayImage/DisplayImage.react.tsx
@@ -49,52 +49,41 @@ const DisplayImage: React.FC<Props> = ({
     });
   }, [images]);
 
-  if (isPostcard) {
-    const aspectRatio = getAspectRatio(sizedImages[0]);
-    const padding = paddingPostcard ? 2 * paddingPostcard : 0;
-    return (
-      <AsyncImage
-        viewStyle={[
-          Styles.postcardImage,
-          {
-            height:
-              aspectRatio > 1
-                ? (WIDTH_POSTCARD - padding) / aspectRatio
-                : WIDTH_POSTCARD,
-            width:
-              aspectRatio > 1
-                ? WIDTH_POSTCARD - padding
-                : WIDTH_POSTCARD * aspectRatio,
-          },
-        ]}
-        loadingBackgroundColor={backgroundColor || Colors.GRAY_LIGHTER}
-        download={!local}
-        local={!!local}
-        autorotate={false}
-        source={sizedImages[0]}
-      />
-    );
-  }
-
   return (
     <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
-      {sizedImages.map((image) => (
-        <AsyncImage
-          key={image.uri}
-          viewStyle={[
-            Styles.letterImage,
-            {
-              height: heightLetter || HEIGHT_LETTER,
-              width: (heightLetter || HEIGHT_LETTER) * getAspectRatio(image),
-            },
-          ]}
-          loadingBackgroundColor={backgroundColor || Colors.GRAY_LIGHTER}
-          download={!local}
-          autorotate={false}
-          local={!!local}
-          source={image}
-        />
-      ))}
+      {sizedImages.map((image) => {
+        const aspectRatio = getAspectRatio(image);
+        const padding = paddingPostcard ? 2 * paddingPostcard : 0;
+        let height = heightLetter || HEIGHT_LETTER;
+        let width = height * aspectRatio;
+        if (isPostcard) {
+          height =
+            aspectRatio > 1
+              ? (WIDTH_POSTCARD - padding) / aspectRatio
+              : WIDTH_POSTCARD;
+          width =
+            aspectRatio > 1
+              ? WIDTH_POSTCARD - padding
+              : WIDTH_POSTCARD * aspectRatio;
+        }
+        return (
+          <AsyncImage
+            key={image.uri}
+            viewStyle={[
+              isPostcard ? Styles.postcardImage : Styles.letterImage,
+              {
+                height,
+                width,
+              },
+            ]}
+            loadingBackgroundColor={backgroundColor || Colors.GRAY_LIGHTER}
+            download={!local}
+            autorotate={false}
+            local={!!local}
+            source={image}
+          />
+        );
+      })}
     </View>
   );
 };

--- a/src/components/DisplayImage/DisplayImage.react.tsx
+++ b/src/components/DisplayImage/DisplayImage.react.tsx
@@ -1,14 +1,19 @@
-import React from 'react';
-import { View, Image as ImageComponent } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { View } from 'react-native';
 import { Image } from 'types';
-import { getAspectRatio } from '@utils';
+import { getAspectRatio, getImageDims } from '@utils';
+import { Colors } from '@styles';
 import Styles, { HEIGHT_LETTER, WIDTH_POSTCARD } from './DisplayImage.styles';
+import AsyncImage from '../AsyncImage/AsyncImage.react';
 
 export interface Props {
   images: Image[];
   isPostcard?: boolean;
   heightLetter?: number;
   paddingPostcard?: number; // additional padding to decrease width
+  updateImages?: (images: Image[]) => void;
+  local?: boolean;
+  backgroundColor?: string;
 }
 
 const DisplayImage: React.FC<Props> = ({
@@ -16,15 +21,40 @@ const DisplayImage: React.FC<Props> = ({
   isPostcard,
   heightLetter,
   paddingPostcard,
+  updateImages,
+  local,
+  backgroundColor,
 }: Props) => {
   if (!images.length) return null;
 
+  const [sizedImages, setSizedImages] = useState(images);
+
+  useEffect(() => {
+    let changed = false;
+    Promise.all(
+      images.map(async (image) => {
+        if (image.width && image.height) return image;
+        changed = true;
+        const dims = await getImageDims(image.uri);
+        return {
+          uri: image.uri,
+          ...dims,
+        };
+      })
+    ).then((newImages) => {
+      setSizedImages(newImages);
+      if (changed && updateImages) {
+        updateImages(newImages);
+      }
+    });
+  }, [images]);
+
   if (isPostcard) {
-    const aspectRatio = getAspectRatio(images[0]);
+    const aspectRatio = getAspectRatio(sizedImages[0]);
     const padding = paddingPostcard ? 2 * paddingPostcard : 0;
     return (
-      <ImageComponent
-        style={[
+      <AsyncImage
+        viewStyle={[
           Styles.postcardImage,
           {
             height:
@@ -37,23 +67,31 @@ const DisplayImage: React.FC<Props> = ({
                 : WIDTH_POSTCARD * aspectRatio,
           },
         ]}
-        source={images[0]}
+        loadingBackgroundColor={backgroundColor || Colors.GRAY_LIGHTER}
+        download={!local}
+        local={!!local}
+        autorotate={false}
+        source={sizedImages[0]}
       />
     );
   }
 
   return (
     <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
-      {images.map((image) => (
-        <ImageComponent
+      {sizedImages.map((image) => (
+        <AsyncImage
           key={image.uri}
-          style={[
+          viewStyle={[
             Styles.letterImage,
             {
               height: heightLetter || HEIGHT_LETTER,
               width: (heightLetter || HEIGHT_LETTER) * getAspectRatio(image),
             },
           ]}
+          loadingBackgroundColor={backgroundColor || Colors.GRAY_LIGHTER}
+          download={!local}
+          autorotate={false}
+          local={!!local}
           source={image}
         />
       ))}

--- a/src/components/DisplayImage/DisplayImage.styles.tsx
+++ b/src/components/DisplayImage/DisplayImage.styles.tsx
@@ -2,7 +2,7 @@ import { StyleSheet } from 'react-native';
 import { WINDOW_WIDTH } from '@utils';
 
 export const HEIGHT_LETTER = 225;
-export const WIDTH_POSTCARD = WINDOW_WIDTH - 40;
+export const WIDTH_POSTCARD = WINDOW_WIDTH - 64;
 
 export default StyleSheet.create({
   postcardImage: {

--- a/src/store/Mail/MailActions.tsx
+++ b/src/store/Mail/MailActions.tsx
@@ -14,6 +14,7 @@ import {
   SET_CONTACTS_MAIL,
   SET_EXISTING_MAIL,
   MailActionTypes,
+  SET_MAIL_IMAGES,
 } from './MailTypes';
 
 export function setComposing(draft: Draft): MailActionTypes {
@@ -113,6 +114,21 @@ export function setExpectedDelivery(
       contactId,
       mailId,
       expectedDelivery,
+    },
+  };
+}
+
+export function setMailImages(
+  images: Image[],
+  contactId: number,
+  mailId: number
+): MailActionTypes {
+  return {
+    type: SET_MAIL_IMAGES,
+    payload: {
+      contactId,
+      mailId,
+      images,
     },
   };
 }

--- a/src/store/Mail/MailReducer.tsx
+++ b/src/store/Mail/MailReducer.tsx
@@ -1,4 +1,4 @@
-import { MailTypes } from 'types';
+import { Mail, MailTypes } from 'types';
 import {
   SET_COMPOSING,
   SET_RECIPIENT_ID,
@@ -15,6 +15,7 @@ import {
   SET_EXISTING_MAIL,
   MailActionTypes,
   MailState,
+  SET_MAIL_IMAGES,
 } from './MailTypes';
 
 const initialState: MailState = {
@@ -33,6 +34,8 @@ export default function LetterReducer(
   action: MailActionTypes
 ): MailState {
   const currentState = { ...state };
+  let ix = -1;
+  let mailItem: Mail;
   switch (action.type) {
     case SET_COMPOSING:
       currentState.composing = action.payload;
@@ -76,7 +79,7 @@ export default function LetterReducer(
       if (!(action.payload.contactId in currentState.existing))
         return currentState;
       for (
-        let ix = 0;
+        ix = 0;
         ix < currentState.existing[action.payload.contactId].length;
         ix += 1
       ) {
@@ -95,7 +98,7 @@ export default function LetterReducer(
       if (!(action.payload.contactId in currentState.existing))
         return currentState;
       for (
-        let ix = 0;
+        ix = 0;
         ix < currentState.existing[action.payload.contactId].length;
         ix += 1
       ) {
@@ -115,7 +118,7 @@ export default function LetterReducer(
       if (!(action.payload.contactId in currentState.existing))
         return currentState;
       for (
-        let ix = 0;
+        ix = 0;
         ix < currentState.existing[action.payload.contactId].length;
         ix += 1
       ) {
@@ -130,6 +133,23 @@ export default function LetterReducer(
         }
       }
       currentState.existing = { ...currentState.existing };
+      return currentState;
+    case SET_MAIL_IMAGES:
+      if (!(action.payload.contactId in currentState.existing))
+        return currentState;
+      ix = currentState.existing[action.payload.contactId].findIndex(
+        (testMail) => testMail.id === action.payload.mailId
+      );
+      if (ix < 0) return currentState;
+      mailItem = currentState.existing[action.payload.contactId][ix];
+      if (mailItem.type === MailTypes.Postcard) {
+        if (!action.payload.images.length) return currentState;
+        [mailItem.design.image] = action.payload.images;
+        currentState.existing[action.payload.contactId][ix] = { ...mailItem };
+        return currentState;
+      }
+      mailItem.images = action.payload.images;
+      currentState.existing[action.payload.contactId][ix] = { ...mailItem };
       return currentState;
     case SET_CONTACTS_MAIL:
       currentState.existing[action.payload.contactId] = action.payload.mail;

--- a/src/store/Mail/MailTypes.tsx
+++ b/src/store/Mail/MailTypes.tsx
@@ -50,6 +50,7 @@ export const SET_ACTIVE = 'mail/set_active';
 export const SET_STATUS = 'mail/set_status';
 export const SET_DATE_CREATED = 'mail/set_date_created';
 export const SET_EXPECTED_DELIVERY = 'mail/set_expected_delivery';
+export const SET_MAIL_IMAGES = 'mail/set_mail_images';
 export const SET_CONTACTS_MAIL = 'mail/set_contacts_mail';
 export const SET_EXISTING_MAIL = 'mail/set_existing_mail';
 
@@ -90,6 +91,15 @@ interface SetExpectedDeliveryAction {
   };
 }
 
+interface SetMailImagesAction {
+  type: typeof SET_MAIL_IMAGES;
+  payload: {
+    contactId: number;
+    mailId: number;
+    images: Image[];
+  };
+}
+
 interface SetContactsMailAction {
   type: typeof SET_CONTACTS_MAIL;
   payload: {
@@ -115,5 +125,6 @@ export type MailActionTypes =
   | SetStatusAction
   | SetDateCreatedAction
   | SetExpectedDeliveryAction
+  | SetMailImagesAction
   | SetContactsMailAction
   | SetExistingMailAction;

--- a/src/views/Compose/ReviewLetter.react.tsx
+++ b/src/views/Compose/ReviewLetter.react.tsx
@@ -168,7 +168,7 @@ class ReviewLetterScreenBase extends React.Component<Props> {
             >
               {this.props.composing.content}
             </Text>
-            <DisplayImage images={this.props.composing.images} />
+            <DisplayImage images={this.props.composing.images} local />
           </ScrollView>
         </View>
         <Text

--- a/src/views/Home/MailTracking.react.tsx
+++ b/src/views/Home/MailTracking.react.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Dispatch } from 'react';
 import { Linking, Text, ScrollView, View, Animated } from 'react-native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { AppStackParamList, Screens } from '@utils/Screens';
@@ -21,6 +21,7 @@ import {
   Contact,
   ProfilePicTypes,
   EntityTypes,
+  Image,
 } from 'types';
 import { format } from 'date-fns';
 import i18n from '@i18n';
@@ -32,6 +33,8 @@ import { WINDOW_WIDTH, ETA_PROCESSED_TO_DELIVERED } from '@utils';
 import { differenceInBusinessDays } from 'date-fns/esm';
 import { checkIfLoading } from '@store/selectors';
 import TrackingEventsPlaceholder from '@components/Loaders/TrackingEventsPlaceholder';
+import { MailActionTypes } from '@store/Mail/MailTypes';
+import { setMailImages } from '@store/Mail/MailActions';
 import Styles from './MailTracking.styles';
 
 type MailTrackingScreenNavigationProp = StackNavigationProp<
@@ -45,6 +48,11 @@ interface Props {
   contact: Contact;
   user: User;
   isLoadingMailDetail: boolean;
+  updateMailImages: (
+    images: Image[],
+    contactId: number,
+    mailId: number
+  ) => void;
 }
 
 interface State {
@@ -345,13 +353,22 @@ class MailTrackingScreenBase extends React.Component<Props, State> {
           </Text>
           <Text style={{ fontSize: 15 }}>{mail.content}</Text>
           {mail.type === MailTypes.Letter && (
-            <DisplayImage images={mail.images} heightLetter={160} />
+            <DisplayImage
+              images={mail.images}
+              heightLetter={160}
+              updateImages={(images) => {
+                this.props.updateMailImages(images, contact.id, mail.id);
+              }}
+            />
           )}
           {mail.type === MailTypes.Postcard && (
             <DisplayImage
               images={[mail.design.image]}
               isPostcard
               paddingPostcard={20}
+              updateImages={(images) => {
+                this.props.updateMailImages(images, contact.id, mail.id);
+              }}
             />
           )}
           <View style={{ height: 40 }} />
@@ -367,6 +384,15 @@ const mapStateToProps = (state: AppState) => ({
   user: state.user.user,
   isLoadingMailDetail: checkIfLoading(state, EntityTypes.MailDetail),
 });
-const MailTrackingScreen = connect(mapStateToProps)(MailTrackingScreenBase);
+
+const mapDispatchToProps = (dispatch: Dispatch<MailActionTypes>) => ({
+  updateMailImages: (images: Image[], contactId: number, mailId: number) =>
+    dispatch(setMailImages(images, contactId, mailId)),
+});
+
+const MailTrackingScreen = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(MailTrackingScreenBase);
 
 export default MailTrackingScreen;

--- a/src/views/MemoryLane/MailDetails.react.tsx
+++ b/src/views/MemoryLane/MailDetails.react.tsx
@@ -1,13 +1,15 @@
-import React from 'react';
+import React, { Dispatch } from 'react';
 import { ScrollView, Text, View } from 'react-native';
 import { AppStackParamList } from '@utils/Screens';
 import { StackNavigationProp } from '@react-navigation/stack';
-import { Mail, MailTypes, MailStatus } from 'types';
+import { Mail, MailTypes, MailStatus, Image } from 'types';
 import { connect } from 'react-redux';
 import { AppState } from '@store/types';
 import { format } from 'date-fns';
 import { Typography } from '@styles';
 import { DisplayImage } from '@components';
+import { MailActionTypes } from '@store/Mail/MailTypes';
+import { setMailImages } from '@store/Mail/MailActions';
 import Styles from './MailDetails.styles';
 
 type MailDetailsScreenNavigationProp = StackNavigationProp<
@@ -18,6 +20,11 @@ type MailDetailsScreenNavigationProp = StackNavigationProp<
 interface Props {
   navigation: MailDetailsScreenNavigationProp;
   mail: Mail;
+  updateMailImages: (
+    images: Image[],
+    contactId: number,
+    mailId: number
+  ) => void;
 }
 
 const MailDetailsScreenBase: React.FC<Props> = (props: Props) => {
@@ -44,13 +51,21 @@ const MailDetailsScreenBase: React.FC<Props> = (props: Props) => {
           {mail.content}
         </Text>
         {mail.type === MailTypes.Letter && (
-          <DisplayImage images={mail.images} />
+          <DisplayImage
+            images={mail.images}
+            updateImages={(images) => {
+              props.updateMailImages(images, mail.recipientId, mail.id);
+            }}
+          />
         )}
         {mail.type === MailTypes.Postcard && (
           <DisplayImage
             images={[mail.design.image]}
             isPostcard
             paddingPostcard={5}
+            updateImages={(images) => {
+              props.updateMailImages(images, mail.recipientId, mail.id);
+            }}
           />
         )}
       </ScrollView>
@@ -73,6 +88,14 @@ const mapStateToProps = (state: AppState) => ({
   mail: state.mail.active ? state.mail.active : blankMail,
 });
 
-const MailDetailsScreen = connect(mapStateToProps)(MailDetailsScreenBase);
+const mapDispatchToProps = (dispatch: Dispatch<MailActionTypes>) => ({
+  updateMailImages: (images: Image[], contactId: number, mailId: number) =>
+    dispatch(setMailImages(images, contactId, mailId)),
+});
+
+const MailDetailsScreen = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(MailDetailsScreenBase);
 
 export default MailDetailsScreen;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Remove the need to `await getImageDims` on initial load.

## Description
<!--- Describe your changes in detail -->
Removed calls to `getImageDims` in initial app loading. Instead, `getImageDims` is only called once an image is actually going to be rendered (in the <DisplayImageComponent />`) and then the store is updated so `getImageDims` never has to be called again for this image.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Make the app faster, especially on initial open.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Pixel emulator.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
