### PR TITLE
[v1.2.7] ImageDims bugs, draft storage limits bugs, bump version

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
     "slug": "Ameelio",
     "privacy": "public",
     "platforms": ["ios", "android", "web"],
-    "version": "1.2.6",
+    "version": "1.2.7",
     "orientation": "portrait",
     "icon": "./src/assets/icons/icon.png",
     "description": "Ameelio's letter platform allows individuals to send free letters to their incarcerated loved ones. ",
@@ -13,7 +13,7 @@
       "color": "#ffffff"
     },
     "android": {
-      "versionCode": 126,
+      "versionCode": 127,
       "package": "com.ameelio.letters_mobile",
       "adaptiveIcon": {
         "foregroundImage": "./src/assets/icons/icon.png",
@@ -31,7 +31,7 @@
       "playStoreUrl": "https://play.google.com/store/apps/details?id=com.ameelio.letters_mobile"
     },
     "ios": {
-      "buildNumber": "1.2.6",
+      "buildNumber": "1.2.7",
       "bundleIdentifier": "com.ameelio.ameelio",
       "infoPlist": {
         "NSCameraUsageDescription": "Ameelio uses the camera to allow users to take photos and attach them to the letters they send to their loved ones. Ameelio also accesses the camera to allow users to take photos for their profile, and the profiles of their loved ones in the app.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3741,9 +3741,9 @@
       }
     },
     "@react-native-community/async-storage": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/async-storage/-/async-storage-1.12.0.tgz",
-      "integrity": "sha512-y3zVxuVyiOxI8TXrvajmYfDbIt2vFNxzV5MiA28v15DQTxDk6uJH3rpc9my+la7u2Tiwt3PpdU2+59ZgZ4h7wA==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/async-storage/-/async-storage-1.12.1.tgz",
+      "integrity": "sha512-70WGaH3PKYASi4BThuEEKMkyAgE9k7VytBqmgPRx3MzJx9/MkspwqJGmn3QLCgHLIFUgF1pit2mWICbRJ3T3lg==",
       "requires": {
         "deep-assign": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@babel/preset-env": "^7.10.2",
     "@expo-google-fonts/inter": "^0.1.0",
     "@expo-google-fonts/poppins": "^0.1.0",
-    "@react-native-community/async-storage": "~1.12.0",
+    "@react-native-community/async-storage": "^1.12.1",
     "@react-native-community/masked-view": "0.1.10",
     "@react-native-community/picker": "1.6.6",
     "@react-native-community/viewpager": "4.1.6",

--- a/src/api/User.ts
+++ b/src/api/User.ts
@@ -6,6 +6,7 @@ import { User, UserLoginInfo, UserRegisterInfo } from '@store/User/UserTypes';
 import { dropdownError } from '@components/Dropdown/Dropdown.react';
 import url from 'url';
 import { setItemAsync, getItemAsync, deleteItemAsync } from 'expo-secure-store';
+import AsyncStorage from '@react-native-community/async-storage';
 import {
   Storage,
   MailTypes,
@@ -13,7 +14,6 @@ import {
   PostcardDesign,
   FamilyConnection,
   UserReferralsInfo,
-  EntityTypes,
 } from 'types';
 import {
   loginUser,
@@ -24,7 +24,6 @@ import {
   setLoadingStatus,
 } from '@store/User/UserActions';
 import { clearContacts } from '@store/Contact/ContactActions';
-import { startAction } from '@store/UI/UIActions';
 
 import i18n from '@i18n';
 import { STATE_TO_ABBREV, ABBREV_TO_STATE, sleep } from '@utils';
@@ -102,7 +101,7 @@ export async function deleteDraft(): Promise<void> {
     deleteItemAsync(Storage.DraftDesignUri),
     deleteItemAsync(Storage.DraftCategoryId),
     deleteItemAsync(Storage.DraftSubcategoryName),
-    deleteItemAsync(Storage.DraftLayout),
+    AsyncStorage.removeItem(Storage.DraftLayout),
   ]);
 }
 
@@ -125,7 +124,10 @@ export async function saveDraft(draft: Draft): Promise<void> {
     if (draft.design.layout) {
       // personal postcard
       Promise.all([
-        setItemAsync(Storage.DraftLayout, JSON.stringify(draft.design.layout)),
+        AsyncStorage.setItem(
+          Storage.DraftLayout,
+          JSON.stringify(draft.design.layout)
+        ),
       ]);
     } else if (draft.design.image.uri && draft.design.subcategoryName) {
       Promise.all([
@@ -177,7 +179,7 @@ export async function loadDraft(): Promise<Draft> {
         draftCategoryId === PERSONAL_OVERRIDE_ID.toString()
       ) {
         // either this is a personal postcard, or there is no categoryId and we assume it is
-        const draftLayout = await getItemAsync(Storage.DraftLayout);
+        const draftLayout = await AsyncStorage.getItem(Storage.DraftLayout);
         const draft: Draft = {
           type: MailTypes.Postcard,
           recipientId: parseInt(draftRecipientId, 10),

--- a/src/components/EditablePostcard/EditablePostcard.react.tsx
+++ b/src/components/EditablePostcard/EditablePostcard.react.tsx
@@ -1,6 +1,6 @@
 import React, { createRef } from 'react';
 import { View, Animated, Text } from 'react-native';
-import { PostcardDesign, Contact } from 'types';
+import { PostcardDesign, Contact, Image } from 'types';
 import Stamp from '@assets/views/Compose/Stamp';
 import i18n from '@i18n';
 import { Typography, Colors } from '@styles';
@@ -68,15 +68,27 @@ class EditablePostcard extends React.Component<Props, State> {
   }
 
   render(): JSX.Element {
-    const image = (
+    const image = this.props.horizontal ? (
       <AsyncImage
         viewStyle={{
-          width: '100%',
-          height: '100%',
+          width: this.props.width,
+          height: this.props.height,
         }}
         source={this.props.design.thumbnail || this.props.design.image}
         onLoad={this.props.onLoad}
         download={!!this.props.design.thumbnail}
+      />
+    ) : (
+      <AsyncImage
+        viewStyle={{
+          width: this.props.height,
+          height: this.props.width,
+          transform: [{ rotateZ: '270deg' }],
+        }}
+        source={this.props.design.thumbnail || this.props.design.image}
+        onLoad={this.props.onLoad}
+        download={!!this.props.design.thumbnail}
+        autorotate={false}
       />
     );
 
@@ -90,7 +102,7 @@ class EditablePostcard extends React.Component<Props, State> {
                   {
                     rotateZ: this.state.rotate.interpolate({
                       inputRange: [0, 1],
-                      outputRange: ['0rad', `${(3.1415926 / 2).toString()}rad`],
+                      outputRange: ['0deg', `90deg`],
                     }),
                   },
                   {

--- a/src/store/Category/CategoryActions.tsx
+++ b/src/store/Category/CategoryActions.tsx
@@ -1,4 +1,4 @@
-import { Category, PostcardDesign } from 'types';
+import { Category, Image, PostcardDesign } from 'types';
 import {
   SET_CATEGORIES,
   ADD_CATEGORY,
@@ -7,6 +7,7 @@ import {
   SET_SUBCATEGORIES,
   ADD_SUBCATEGORY,
   SET_SUBCATEGORY,
+  SET_DESIGN_IMAGE,
   REMOVE_SUBCATEGORY,
   CategoryActionTypes,
   SET_LAST_UPDATED,
@@ -69,6 +70,18 @@ export function setSubcategory(
   return {
     type: SET_SUBCATEGORY,
     payload: { categoryId, name, designs },
+  };
+}
+
+export function setDesignImage(
+  categoryId: number,
+  subcategoryName: string,
+  designId: number,
+  image: Image
+): CategoryActionTypes {
+  return {
+    type: SET_DESIGN_IMAGE,
+    payload: { categoryId, subcategoryName, designId, image },
   };
 }
 

--- a/src/store/Category/CategoryReducer.tsx
+++ b/src/store/Category/CategoryReducer.tsx
@@ -1,4 +1,4 @@
-import { Category } from 'types';
+import { Category, PostcardDesign } from 'types';
 import {
   SET_CATEGORIES,
   ADD_CATEGORY,
@@ -7,6 +7,7 @@ import {
   SET_SUBCATEGORIES,
   ADD_SUBCATEGORY,
   SET_SUBCATEGORY,
+  SET_DESIGN_IMAGE,
   REMOVE_SUBCATEGORY,
   CategoryActionTypes,
   CategoryState,
@@ -24,7 +25,9 @@ export default function CategoryReducer(
 ): CategoryState {
   const currentState = { ...state };
   let ix = -1;
+  let jx = -1;
   let categories: Category[] = [];
+  let newSubcategory: PostcardDesign[];
   switch (action.type) {
     case SET_CATEGORIES:
       currentState.categories = action.payload;
@@ -73,6 +76,31 @@ export default function CategoryReducer(
       if (ix < 0) return currentState;
       currentState.categories[ix].subcategories[action.payload.name] =
         action.payload.designs;
+      return currentState;
+    case SET_DESIGN_IMAGE:
+      ix = currentState.categories.findIndex(
+        (value) => value.id === action.payload.categoryId
+      );
+      if (ix < 0) return currentState;
+      if (
+        !(
+          action.payload.subcategoryName in
+          currentState.categories[ix].subcategories
+        )
+      )
+        return currentState;
+      newSubcategory =
+        currentState.categories[ix].subcategories[
+          action.payload.subcategoryName
+        ];
+      jx = newSubcategory.findIndex(
+        (design) => design.id === action.payload.designId
+      );
+      if (jx < 0) return currentState;
+      newSubcategory[jx].image = action.payload.image;
+      currentState.categories[ix].subcategories[
+        action.payload.subcategoryName
+      ] = [...newSubcategory];
       return currentState;
     case REMOVE_SUBCATEGORY:
       categories = currentState.categories.filter(

--- a/src/store/Category/CategoryTypes.tsx
+++ b/src/store/Category/CategoryTypes.tsx
@@ -1,4 +1,4 @@
-import { Category, PostcardDesign } from 'types';
+import { Category, Image, PostcardDesign } from 'types';
 
 export const SET_CATEGORIES = 'category/set_categories';
 export const ADD_CATEGORY = 'category/add_category';
@@ -8,6 +8,7 @@ export const REMOVE_CATEGORY = 'category/remove_category';
 export const SET_SUBCATEGORIES = 'category/set_subcategories';
 export const ADD_SUBCATEGORY = 'category/add_subcategory';
 export const SET_SUBCATEGORY = 'category/set_subcategory';
+export const SET_DESIGN_IMAGE = 'category/set_design_image';
 export const REMOVE_SUBCATEGORY = 'category/remove_subcategory';
 
 export const SET_LAST_UPDATED = 'cateogry/set_last_updated';
@@ -55,6 +56,16 @@ interface SetSubcategoryAction {
   payload: { categoryId: number; name: string; designs: PostcardDesign[] };
 }
 
+interface SetDesignImageAction {
+  type: typeof SET_DESIGN_IMAGE;
+  payload: {
+    categoryId: number;
+    subcategoryName: string;
+    designId: number;
+    image: Image;
+  };
+}
+
 interface RemoveSubcategoryAction {
   type: typeof REMOVE_SUBCATEGORY;
   payload: { categoryId: number; name: string };
@@ -73,5 +84,6 @@ export type CategoryActionTypes =
   | SetSubcategoriesAction
   | AddSubcategoryAction
   | SetSubcategoryAction
+  | SetDesignImageAction
   | RemoveSubcategoryAction
   | SetLastUpdatedAction;

--- a/src/views/Home/ContactSelector.react.tsx
+++ b/src/views/Home/ContactSelector.react.tsx
@@ -191,7 +191,7 @@ class ContactSelectorScreenBase extends React.Component<Props> {
 
   renderListHeader() {
     return (
-      <View>
+      <View style={{ paddingTop: 16 }}>
         {this.renderReferralCard()}
         <Text
           style={[

--- a/src/views/Home/ContactSelector.styles.tsx
+++ b/src/views/Home/ContactSelector.styles.tsx
@@ -8,8 +8,7 @@ export default StyleSheet.create({
     backgroundColor: '#EDEDED',
     flexDirection: 'column',
     justifyContent: 'center',
-    padding: 16,
-    paddingBottom: 0,
+    paddingHorizontal: 16,
   },
   contactCard: {
     backgroundColor: 'white',

--- a/src/views/Home/MailTracking.react.tsx
+++ b/src/views/Home/MailTracking.react.tsx
@@ -153,23 +153,27 @@ class MailTrackingScreenBase extends React.Component<Props, State> {
               </View>
             </View>
           )}
-          <View style={[Styles.endpointsContainer]}>
-            <View>
-              <Text
-                style={[Typography.FONT_SEMIBOLD, Styles.endpointCityLabel]}
-              >
-                {user.city}
-              </Text>
+          <View>
+            <View style={[Styles.endpointsContainer]}>
+              <View style={{ paddingRight: 8, maxWidth: '50%' }}>
+                <Text
+                  style={[Typography.FONT_SEMIBOLD, Styles.endpointCityLabel]}
+                >
+                  {user.city}
+                </Text>
+              </View>
+
+              <View style={{ paddingLeft: 8, maxWidth: '50%' }}>
+                <Text
+                  style={[Typography.FONT_SEMIBOLD, Styles.endpointCityLabel]}
+                >
+                  {contact.facility.name}
+                </Text>
+              </View>
+            </View>
+            <View style={[Styles.endpointsContainer]}>
               <Text style={[Styles.endpointDate]}>
                 {format(new Date(mail.dateCreated), 'MM/dd')}
-              </Text>
-            </View>
-
-            <View>
-              <Text
-                style={[Typography.FONT_SEMIBOLD, Styles.endpointCityLabel]}
-              >
-                {contact.facility.name}
               </Text>
               <Text style={[{ textAlign: 'right' }, Styles.endpointDate]}>
                 {format(new Date(mail.expectedDelivery), 'MM/dd')}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Cleanup of some of the changes i made earlier! 

## Description
<!--- Describe your changes in detail -->
Fixed an image rotation bug on postcard designs that was caused by changes to AsyncImage. Transitioned to using `AsyncStorage` instead of `SecureStore` to store personal postcard drafts since it has a larger storage size.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes / tweaks!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Able to save drafts on pixel and iphone 8, image rotation bug went away, warning on draft save went away.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)