### PR TITLE
[Topbar] Use redux state instead of refs.

### DIFF
--- a/src/api/Mail.ts
+++ b/src/api/Mail.ts
@@ -631,9 +631,9 @@ export async function getSubcategoriesById(
   const subNames = Object.keys(data);
   for (let ix = 0; ix < subNames.length; ix += 1) {
     const subName = subNames[ix];
-    cleanData[subName] = data[subName].map((raw: RawDesign) =>
-      cleanDesign(raw, categoryId, subName)
-    );
+    cleanData[subName] = data[subName]
+      .map((raw: RawDesign) => cleanDesign(raw, categoryId, subName))
+      .reverse();
   }
   return cleanData;
 }

--- a/src/components/Card/Card.styles.tsx
+++ b/src/components/Card/Card.styles.tsx
@@ -189,7 +189,7 @@ export default StyleSheet.create({
     height: 144,
     position: 'absolute',
     borderRadius: 4,
-    zIndex: 3,
+    zIndex: 6,
     borderColor: '#DCDCDC',
     borderWidth: 1,
   },

--- a/src/components/Card/PremiumSubcategorySelector.react.tsx
+++ b/src/components/Card/PremiumSubcategorySelector.react.tsx
@@ -26,6 +26,7 @@ const PremiumSubcategorySelector: React.FC<Props> = ({
           CardStyles.premiumCardBox,
           {
             elevation: 6,
+            zIndex: 6,
             backgroundColor: 'white',
             top: 8,
             left: 8,

--- a/src/components/ProfilePic/ProfilePic.react.tsx
+++ b/src/components/ProfilePic/ProfilePic.react.tsx
@@ -18,7 +18,11 @@ export interface Props {
 function mapProfileTypeToStyle(type: ProfilePicTypes) {
   switch (type) {
     case ProfilePicTypes.ReferralDashboardConnection:
-    case ProfilePicTypes.Topbar:
+      return {
+        image: Styles.referralPic,
+        background: Styles.referralBackground,
+      };
+    case ProfilePicTypes.TabBar:
       return { image: Styles.userPic, background: Styles.userBackground };
     case ProfilePicTypes.ReferralDashboard:
       return {
@@ -93,19 +97,26 @@ const ProfilePic: React.FC<Props> = (props: Props) => {
       }
       style={mapProfileTypeToStyle(props.type).background}
     >
-      <TouchableOpacity
-        style={mapProfileTypeToStyle(props.type).background}
-        onPress={async () => {
-          if (props.disabled) return;
-          if (props.type === ProfilePicTypes.SingleContact)
-            navigate(Screens.UpdateContact);
-          else if (props.type === ProfilePicTypes.Topbar)
-            navigate(Screens.UpdateProfile);
-        }}
-        testID="profilePicture"
-      >
-        {insideCircle}
-      </TouchableOpacity>
+      {props.type === ProfilePicTypes.TabBar ? (
+        <View
+          style={mapProfileTypeToStyle(props.type).background}
+          testID="profilePicture"
+        >
+          {insideCircle}
+        </View>
+      ) : (
+        <TouchableOpacity
+          style={mapProfileTypeToStyle(props.type).background}
+          onPress={async () => {
+            if (props.disabled) return;
+            if (props.type === ProfilePicTypes.SingleContact)
+              navigate(Screens.UpdateContact);
+          }}
+          testID="profilePicture"
+        >
+          {insideCircle}
+        </TouchableOpacity>
+      )}
     </View>
   );
 };

--- a/src/components/ProfilePic/ProfilePic.styles.tsx
+++ b/src/components/ProfilePic/ProfilePic.styles.tsx
@@ -1,7 +1,8 @@
 import { StyleSheet } from 'react-native';
 import { Colors } from '@styles';
 
-const userSize = 46;
+const userSize = 24;
+const referralSize = 42;
 const contactSize = 80;
 const singleContactSize = 130;
 const avatarSize = 30;
@@ -37,6 +38,15 @@ export default StyleSheet.create({
     overflow: 'hidden',
     backgroundColor: Colors.AMEELIO_LIGHT_GRAY,
   },
+  referralBackground: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: referralSize,
+    height: referralSize,
+    borderRadius: userSize / 2,
+    overflow: 'hidden',
+    backgroundColor: Colors.AMEELIO_LIGHT_GRAY,
+  },
   avatarBackground: {
     alignItems: 'center',
     justifyContent: 'center',
@@ -66,6 +76,10 @@ export default StyleSheet.create({
   userPic: {
     width: userSize,
     height: userSize,
+  },
+  referralPic: {
+    width: referralSize,
+    height: referralSize,
   },
   avatarPic: {
     width: avatarSize,

--- a/src/components/Topbar/HeaderLeft.react.tsx
+++ b/src/components/Topbar/HeaderLeft.react.tsx
@@ -1,75 +1,53 @@
-import React, { createRef } from 'react';
+import React from 'react';
 import { Keyboard, TouchableOpacity, View } from 'react-native';
 import BackButton from '@assets/components/Topbar/BackButton';
 import Icon from '@components/Icon/Icon.react';
-import { TopbarBackAction } from 'types';
+import { TopbarLeft } from 'types';
+import { AppState } from '@store/types';
+import { connect } from 'react-redux';
 import Styles from './Topbar.styles';
 
 interface Props {
-  canGoBack: boolean;
-  onPress: (() => void) | undefined;
-  route: string;
+  topbarLeft: TopbarLeft | null;
+  onPress?: () => void;
+  canGoBack?: boolean;
 }
 
-interface State {
-  backOverride?: TopbarBackAction;
-}
-
-class HeaderLeftBase extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      backOverride: undefined,
-    };
-  }
-
-  render() {
-    return (
-      <View style={[Styles.sideContainer, Styles.leftContainer]}>
-        <TouchableOpacity
-          onPress={() => {
-            Keyboard.dismiss();
-            if (this.state.backOverride) {
-              this.state.backOverride.action();
-            } else if (this.props.onPress) this.props.onPress();
-          }}
-          style={{
-            width: 40,
-            padding: 8,
-            justifyContent: 'center',
-            alignItems: 'center',
-          }}
-        >
-          {this.props.canGoBack && <Icon svg={BackButton} />}
-        </TouchableOpacity>
-      </View>
-    );
-  }
-}
-
-const headerLeftRef = createRef<HeaderLeftBase>();
-
-const HeaderLeft = ({
-  canGoBack,
+const HeaderLeftBase: React.FC<Props> = ({
+  topbarLeft,
   onPress,
-  route,
-}: {
-  canGoBack: boolean;
-  onPress: (() => void) | undefined;
-  route: string;
-}): JSX.Element => (
-  <HeaderLeftBase
-    ref={headerLeftRef}
-    canGoBack={canGoBack}
-    onPress={onPress}
-    route={route}
-  />
+  canGoBack,
+}: Props) => (
+  <View style={[Styles.sideContainer, Styles.leftContainer]}>
+    <TouchableOpacity
+      onPress={() => {
+        Keyboard.dismiss();
+        if (topbarLeft) {
+          if (topbarLeft.action) topbarLeft.action();
+        } else if (onPress) {
+          onPress();
+        }
+      }}
+      style={{
+        width: 40,
+        padding: 8,
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+    >
+      {(canGoBack || topbarLeft?.canGoBack) && <Icon svg={BackButton} />}
+    </TouchableOpacity>
+  </View>
 );
 
-export const setBackOverride = (
-  backOverride: TopbarBackAction | undefined
-): void => {
-  if (headerLeftRef.current) headerLeftRef.current.setState({ backOverride });
+HeaderLeftBase.defaultProps = {
+  onPress: () => null,
+  canGoBack: false,
 };
+
+const mapStateToProps = (state: AppState) => ({
+  topbarLeft: state.ui.topbarLeft,
+});
+const HeaderLeft = connect(mapStateToProps)(HeaderLeftBase);
 
 export default HeaderLeft;

--- a/src/components/Topbar/HeaderRight.react.tsx
+++ b/src/components/Topbar/HeaderRight.react.tsx
@@ -1,92 +1,35 @@
+import React from 'react';
 import Button from '@components/Button/Button.react';
-import ProfilePic from '@components/ProfilePic/ProfilePic.react';
 import { AppState } from '@store/types';
-import { UserState } from '@store/User/UserTypes';
-import { ProfilePicTypes, TopbarRouteAction } from 'types';
-import React, { createRef } from 'react';
+import { TopbarRight } from 'types';
 import { Keyboard, View } from 'react-native';
 import { connect } from 'react-redux';
 import Styles from './Topbar.styles';
 
 interface Props {
-  userState: UserState;
+  topbarRight: TopbarRight | null;
 }
 
-interface State {
-  profile: boolean;
-  profileOverride?: {
-    enabled: boolean;
-    text: string;
-    action: () => void | Promise<void>;
-    blocking?: boolean;
-  };
-}
-
-class HeaderRightBase extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      profile: false,
-    };
-  }
-
-  render() {
-    let content = null;
-    if (this.state.profile && this.props.userState.authInfo.isLoggedIn) {
-      content = (
-        <ProfilePic
-          firstName={this.props.userState.user.firstName}
-          lastName={this.props.userState.user.lastName}
-          imageUri={this.props.userState.user.photo?.uri}
-          type={ProfilePicTypes.Topbar}
-        />
-      );
-    } else if (this.state.profileOverride) {
-      content = (
-        <Button
-          enabled={this.state.profileOverride.enabled}
-          blocking={this.state.profileOverride.blocking}
-          onPress={async () => {
-            Keyboard.dismiss();
-            if (this.state.profileOverride)
-              await this.state.profileOverride.action();
-          }}
-          buttonText={this.state.profileOverride.text}
-          containerStyle={{ borderRadius: 20 }}
-        />
-      );
-    }
-    return (
-      <View style={[Styles.sideContainer, Styles.rightContainer]}>
-        {content}
-      </View>
-    );
-  }
-}
-
-const mapStateToProps = (state: AppState) => ({
-  userState: state.user,
-});
-
-const HeaderRightConnected = connect(mapStateToProps, null, null, {
-  forwardRef: true,
-})(HeaderRightBase);
-
-export const headerRightRef = createRef<HeaderRightBase>();
-
-const HeaderRight = (): JSX.Element => (
-  <HeaderRightConnected ref={headerRightRef} />
+const HeaderRightBase: React.FC<Props> = ({ topbarRight }: Props) => (
+  <View style={[Styles.sideContainer, Styles.rightContainer]}>
+    {topbarRight && (
+      <Button
+        enabled={topbarRight.enabled}
+        blocking={topbarRight.blocking}
+        onPress={async () => {
+          Keyboard.dismiss();
+          await topbarRight.action();
+        }}
+        buttonText={topbarRight.text}
+        containerStyle={{ borderRadius: 20 }}
+      />
+    )}
+  </View>
 );
 
-export const setProfile = (val: boolean): void => {
-  if (headerRightRef.current) headerRightRef.current.setState({ profile: val });
-};
-
-export const setProfileOverride = (
-  override: TopbarRouteAction | undefined
-): void => {
-  if (headerRightRef.current)
-    headerRightRef.current.setState({ profileOverride: override });
-};
+const mapStateToProps = (state: AppState) => ({
+  topbarRight: state.ui.topbarRight,
+});
+const HeaderRight = connect(mapStateToProps)(HeaderRightBase);
 
 export default HeaderRight;

--- a/src/components/Topbar/index.ts
+++ b/src/components/Topbar/index.ts
@@ -1,4 +1,0 @@
-import { setBackOverride } from './HeaderLeft.react';
-import { setProfile, setProfileOverride } from './HeaderRight.react';
-
-export { setBackOverride, setProfile, setProfileOverride };

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3,7 +3,8 @@
     "home": "Home",
     "store": "Store",
     "login": "Login",
-    "register": "Register"
+    "register": "Register",
+    "profile": "Profile"
   },
   "Error": {
     "network": "Network Error",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -3,7 +3,8 @@
     "home": "Inicio",
     "store": "Tienda",
     "login": "Iniciar sesión",
-    "register": "Regístrate"
+    "register": "Regístrate",
+    "profile": "Perfil"
   },
   "Error": {
     "network": "Error de red",

--- a/src/navigations/Auth.tsx
+++ b/src/navigations/Auth.tsx
@@ -34,8 +34,7 @@ const Auth: React.FC = () => {
         headerLeft: (leftProps) => (
           <HeaderLeft
             canGoBack={!!leftProps.canGoBack}
-            onPress={leftProps.onPress}
-            route={route.name}
+            onPress={leftProps.onPress ? leftProps.onPress : () => null}
           />
         ),
         headerRight: () => {

--- a/src/navigations/Home.tsx
+++ b/src/navigations/Home.tsx
@@ -28,16 +28,11 @@ import {
   SupportFAQDetailScreen,
   SupportFAQScreen,
   UpdateContactScreen,
-  UpdateProfileScreen,
 } from '@views';
 import { HeaderLeft, HeaderRight, HeaderTitle } from '@components';
 import { BAR_HEIGHT } from '@utils/Constants';
 import { HomeStack } from './Navigators';
-import {
-  leftRightTransition,
-  topBottomTransition,
-  bottomTopTransition,
-} from './Transitions';
+import { leftRightTransition, bottomTopTransition } from './Transitions';
 
 const Home: React.FC = () => {
   return (
@@ -174,11 +169,6 @@ const Home: React.FC = () => {
         name={Screens.UpdateContact}
         component={UpdateContactScreen}
         options={{ cardStyleInterpolator: bottomTopTransition }}
-      />
-      <HomeStack.Screen
-        name={Screens.UpdateProfile}
-        component={UpdateProfileScreen}
-        options={{ cardStyleInterpolator: topBottomTransition }}
       />
       <HomeStack.Screen
         name={Screens.InmateLocator}

--- a/src/navigations/Home.tsx
+++ b/src/navigations/Home.tsx
@@ -60,7 +60,6 @@ const Home: React.FC = () => {
           <HeaderLeft
             canGoBack={!!leftProps.canGoBack}
             onPress={leftProps.onPress}
-            route={route.name}
           />
         ),
         headerRight: () => {

--- a/src/navigations/Navigators.tsx
+++ b/src/navigations/Navigators.tsx
@@ -9,4 +9,6 @@ const HomeStack = createStackNavigator();
 
 const StoreStack = createStackNavigator();
 
-export { RootTab, AuthStack, HomeStack, StoreStack };
+const ProfileStack = createStackNavigator();
+
+export { RootTab, AuthStack, HomeStack, StoreStack, ProfileStack };

--- a/src/navigations/Profile.tsx
+++ b/src/navigations/Profile.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { UpdateProfileScreen } from '@views';
+import { getDetailsFromRouteName, Screens } from '@utils/Screens';
+import { HeaderTitle, HeaderRight, HeaderLeft } from '@components';
+import { BAR_HEIGHT } from '@utils/Constants';
+import { ProfileStack } from './Navigators';
+
+const Store: React.FC = () => {
+  return (
+    <ProfileStack.Navigator
+      screenOptions={({ route }) => ({
+        headerShown: getDetailsFromRouteName(route.name).headerVisible,
+        headerStyle: { height: BAR_HEIGHT },
+        headerTitle: (titleProps) => {
+          return (
+            <HeaderTitle
+              title={
+                titleProps.children
+                  ? getDetailsFromRouteName(titleProps.children).title
+                  : ''
+              }
+            />
+          );
+        },
+        headerLeft: (leftProps) => (
+          <HeaderLeft
+            canGoBack={!!leftProps.canGoBack}
+            onPress={leftProps.onPress}
+          />
+        ),
+        headerRight: () => {
+          return <HeaderRight />;
+        },
+      })}
+    >
+      <ProfileStack.Screen
+        name={Screens.UpdateProfile}
+        component={UpdateProfileScreen}
+      />
+    </ProfileStack.Navigator>
+  );
+};
+
+export default Store;

--- a/src/navigations/Store.tsx
+++ b/src/navigations/Store.tsx
@@ -38,7 +38,6 @@ const Store: React.FC = () => {
           <HeaderLeft
             canGoBack={!!leftProps.canGoBack}
             onPress={leftProps.onPress}
-            route={route.name}
           />
         ),
         headerRight: () => {

--- a/src/store/UI/UIActions.ts
+++ b/src/store/UI/UIActions.ts
@@ -1,5 +1,11 @@
-import { EntityTypes } from 'types';
-import { START_ACTION, STOP_ACTION, UIActionTypes } from './UITypes';
+import { EntityTypes, TopbarLeft, TopbarRight } from 'types';
+import {
+  START_ACTION,
+  STOP_ACTION,
+  SET_TOPBAR_RIGHT,
+  SET_TOPBAR_LEFT,
+  UIActionTypes,
+} from './UITypes';
 
 export const startAction = (entity: EntityTypes): UIActionTypes => ({
   type: START_ACTION,
@@ -9,4 +15,14 @@ export const startAction = (entity: EntityTypes): UIActionTypes => ({
 export const stopAction = (entity: EntityTypes): UIActionTypes => ({
   type: STOP_ACTION,
   payload: entity,
+});
+
+export const setTopbarRight = (details: TopbarRight | null): UIActionTypes => ({
+  type: SET_TOPBAR_RIGHT,
+  payload: details,
+});
+
+export const setTopbarLeft = (details: TopbarLeft | null): UIActionTypes => ({
+  type: SET_TOPBAR_LEFT,
+  payload: details,
 });

--- a/src/store/UI/UIReducer.ts
+++ b/src/store/UI/UIReducer.ts
@@ -1,10 +1,19 @@
-import { UIState, START_ACTION, STOP_ACTION, UIActionTypes } from './UITypes';
+import {
+  UIState,
+  START_ACTION,
+  STOP_ACTION,
+  UIActionTypes,
+  SET_TOPBAR_RIGHT,
+  SET_TOPBAR_LEFT,
+} from './UITypes';
 
 // creates a data loader for different data entities
 const initialState: UIState = {
   loader: {
     actions: [],
   },
+  topbarRight: null,
+  topbarLeft: null,
 };
 
 const UIReducer = (state = initialState, action: UIActionTypes): UIState => {
@@ -26,6 +35,16 @@ const UIReducer = (state = initialState, action: UIActionTypes): UIState => {
           ...loader,
           actions: actions.filter((item) => item !== action.payload),
         },
+      };
+    case SET_TOPBAR_RIGHT:
+      return {
+        ...state,
+        topbarRight: action.payload,
+      };
+    case SET_TOPBAR_LEFT:
+      return {
+        ...state,
+        topbarLeft: action.payload,
       };
     default:
       return state;

--- a/src/store/UI/UITypes.ts
+++ b/src/store/UI/UITypes.ts
@@ -1,14 +1,19 @@
-import { EntityTypes } from 'types';
+import { EntityTypes, TopbarLeft, TopbarRight } from 'types';
 
 export const START_ACTION = 'ui/start_action';
 export const STOP_ACTION = 'ui/stop_action';
 export const REFRESH_ACTION_START = 'ui/refresh_action_start';
 export const REFRESH_ACTION_STOP = 'ui/refresh_action_stop';
 
+export const SET_TOPBAR_RIGHT = 'ui/set_topbar_right';
+export const SET_TOPBAR_LEFT = 'ui/set_topbar_left';
+
 export interface UIState {
   loader: {
     actions: EntityTypes[];
   };
+  topbarRight: TopbarRight | null;
+  topbarLeft: TopbarLeft | null;
 }
 
 export interface StartAction {
@@ -21,4 +26,18 @@ export interface StopAction {
   payload: EntityTypes;
 }
 
-export type UIActionTypes = StartAction | StopAction;
+export interface SetTopbarRightAction {
+  type: typeof SET_TOPBAR_RIGHT;
+  payload: TopbarRight | null;
+}
+
+export interface SetTopbarLeftAction {
+  type: typeof SET_TOPBAR_LEFT;
+  payload: TopbarLeft | null;
+}
+
+export type UIActionTypes =
+  | StartAction
+  | StopAction
+  | SetTopbarRightAction
+  | SetTopbarLeftAction;

--- a/src/types.ts
+++ b/src/types.ts
@@ -327,17 +327,6 @@ export enum Storage {
   DraftPostcardSize = 'Ameelio-DraftPostcardSize',
 }
 
-export type TopbarBackAction = {
-  action: () => void | Promise<void>;
-};
-
-export type TopbarRouteAction = {
-  enabled: boolean;
-  text: string;
-  action: () => void | Promise<void>;
-  blocking?: boolean;
-};
-
 export type DesignBottomDetails = 'layout' | 'design' | 'stickers';
 
 export type TextBottomDetails = 'color' | 'font';
@@ -384,6 +373,19 @@ export enum EntityTypes {
   PremiumStoreItems = 'PremiumStoreItems',
   PremiumTransactions = 'PremiumTransactions',
   StripeTransactions = 'StripeTransactions',
+}
+
+// UI
+export interface TopbarRight {
+  enabled: boolean;
+  text: string;
+  action: () => void | Promise<void>;
+  blocking?: boolean;
+}
+
+export interface TopbarLeft {
+  canGoBack?: boolean;
+  action?: () => void | Promise<void>;
 }
 
 export interface RouteDetails {

--- a/src/types.ts
+++ b/src/types.ts
@@ -306,7 +306,7 @@ export interface UserReferralsInfo {
 
 // Miscelaneous
 export enum ProfilePicTypes {
-  Topbar = 'Topbar',
+  TabBar = 'TabBar',
   Contact = 'Contact',
   SingleContact = 'SingleContact',
   Avatar = 'Avatar',
@@ -390,7 +390,8 @@ export interface TopbarLeft {
 
 export interface RouteDetails {
   title: string;
-  profile?: boolean;
   headerVisible?: boolean;
   tabsVisible?: boolean;
+  customTopRight?: boolean;
+  customTopLeft?: boolean;
 }

--- a/src/utils/Screens.ts
+++ b/src/utils/Screens.ts
@@ -16,6 +16,7 @@ export enum Tabs {
   Home = 'Home',
   Splash = 'Splash',
   Store = 'Store',
+  Profile = 'Profile',
 }
 
 export enum Screens {
@@ -143,79 +144,74 @@ export type AppStackParamList = {
 };
 
 export const mapRouteNameToDetails: Record<Screens, RouteDetails> = {
-  Begin: { title: '', profile: false, headerVisible: false },
-  Splash: { title: '', profile: false, headerVisible: false },
-  Login: { title: i18n.t('Screens.login'), profile: false },
-  Terms: { title: i18n.t('Screens.termsOfService'), profile: false },
-  Privacy: { title: i18n.t('Screens.privacyPolicy'), profile: false },
-  RegisterCreds: { title: i18n.t('Screens.register'), profile: false },
-  RegisterPersonal: { title: i18n.t('Screens.register'), profile: false },
-  RegisterAddress: { title: i18n.t('Screens.register'), profile: false },
-  ChooseCategory: { title: i18n.t('Screens.compose'), profile: false },
-  ChooseOption: { title: i18n.t('Screens.compose'), profile: false },
+  Begin: { title: '', headerVisible: false },
+  Splash: { title: '', headerVisible: false },
+  Login: { title: i18n.t('Screens.login') },
+  Terms: { title: i18n.t('Screens.termsOfService') },
+  Privacy: { title: i18n.t('Screens.privacyPolicy') },
+  RegisterCreds: { title: i18n.t('Screens.register'), customTopRight: true },
+  RegisterPersonal: { title: i18n.t('Screens.register'), customTopRight: true },
+  RegisterAddress: { title: i18n.t('Screens.register'), customTopRight: true },
+  ChooseCategory: { title: i18n.t('Screens.compose') },
+  ChooseOption: { title: i18n.t('Screens.compose') },
   ComposeLetter: {
     title: i18n.t('Screens.compose'),
-    profile: false,
     tabsVisible: false,
+    customTopRight: true,
   },
   ComposePersonal: {
     title: i18n.t('Screens.compose'),
-    profile: false,
     tabsVisible: false,
+    customTopRight: true,
+    customTopLeft: true,
   },
   ComposePostcard: {
     title: i18n.t('Screens.compose'),
-    profile: false,
     tabsVisible: false,
+    customTopRight: true,
+    customTopLeft: true,
   },
   ContactInfo: {
     title: i18n.t('Screens.contactInfo'),
-    profile: false,
     tabsVisible: false,
+    customTopRight: true,
   },
   ContactInmateInfo: {
     title: i18n.t('Screens.contactInmateInfo'),
-    profile: false,
     tabsVisible: false,
+    customTopRight: true,
   },
   ContactSelector: { title: i18n.t('Screens.contacts') },
   CreditPackStore: {
     title: i18n.t('Screens.creditPackStore'),
-    profile: false,
     tabsVisible: false,
   },
   CreditPackCheckoutWebView: {
     title: i18n.t('Screens.creditPackStore'),
-    profile: false,
   },
   CreditPackPurchaseSuccess: {
     title: i18n.t('Screens.creditPackStore'),
-    profile: false,
   },
-  DeliveryReporting: { title: '', profile: false },
-  FacilityDirectory: { title: '', profile: false },
+  DeliveryReporting: { title: '' },
+  FacilityDirectory: { title: '', tabsVisible: false, customTopRight: true },
   IntroContact: {
     title: i18n.t('Screens.introContact'),
-    profile: false,
     tabsVisible: false,
+    customTopRight: true,
   },
   InmateLocator: {
     title: i18n.t('Screens.inmateLocator'),
-    profile: false,
     tabsVisible: false,
   },
   Issues: {
     title: i18n.t('Screens.issues'),
-    profile: false,
     tabsVisible: false,
   },
   IssuesDetail: {
     title: '',
-    profile: false,
   },
   IssuesDetailSecondary: {
     title: '',
-    profile: false,
   },
   MailDetails: { title: i18n.t('Screens.letterDetails') },
   MailTracking: { title: i18n.t('Screens.tracking') },
@@ -227,79 +223,74 @@ export const mapRouteNameToDetails: Record<Screens, RouteDetails> = {
   },
   ReferFriends: {
     title: i18n.t('Screens.spreadTheWord'),
-    profile: false,
     tabsVisible: false,
   },
   ReviewLetter: {
     title: i18n.t('Screens.lastStep'),
-    profile: false,
     tabsVisible: false,
+    customTopRight: true,
   },
   ReviewPostcard: {
     title: i18n.t('Screens.reviewPostcard'),
-    profile: false,
     tabsVisible: false,
+    customTopRight: true,
   },
   ReviewContact: {
     title: i18n.t('Screens.reviewContact'),
-    profile: false,
     tabsVisible: false,
   },
   SelectPostcardSize: {
     title: i18n.t('Screens.compose'),
-    profile: false,
     tabsVisible: false,
+    customTopRight: true,
   },
   SelectRecipient: {
     title: i18n.t('Screens.selectRecipient'),
-    profile: false,
     tabsVisible: false,
   },
-  Setup: { title: '', profile: false },
+  Setup: { title: '' },
   SingleContact: { title: i18n.t('Screens.home') },
-  Store: { title: i18n.t('Screens.store'), profile: true },
-  SupportFAQ: { title: '', profile: false },
-  SupportFAQDetail: { title: '', profile: false },
+  Store: { title: i18n.t('Screens.store') },
+  SupportFAQ: { title: '' },
+  SupportFAQDetail: { title: '' },
   StoreItem: {
     title: i18n.t('Screens.storeItem'),
-    profile: false,
     tabsVisible: false,
   },
   StoreItemPreview: {
     title: i18n.t('Screens.storeItemPreview'),
-    profile: false,
     tabsVisible: false,
   },
   StoreItemPurchaseSuccess: {
     title: i18n.t('Screens.storeItemPreview'),
-    profile: false,
     tabsVisible: false,
   },
   TransactionHistory: { title: i18n.t('Screens.transactionHistory') },
   UpdateContact: {
     title: i18n.t('Screens.updateContact'),
-    profile: false,
     tabsVisible: false,
+    customTopRight: true,
   },
   UpdateProfile: {
     title: i18n.t('Screens.updateProfile'),
-    profile: false,
-    tabsVisible: false,
+    customTopRight: true,
   },
 };
 
 export function getDetailsFromRouteName(screen: string): RouteDetails {
   if (screen in mapRouteNameToDetails)
     return {
-      profile: true,
       headerVisible: true,
       tabsVisible: true,
+      customTopLeft: false,
+      customTopRight: false,
       ...mapRouteNameToDetails[screen as Screens],
     };
   return {
     title: '',
-    profile: false,
     headerVisible: true,
     tabsVisible: true,
+    customTopLeft: false,
+    customTopRight: false,
   };
 }

--- a/src/views/AddContact/ContactInfo.react.tsx
+++ b/src/views/AddContact/ContactInfo.react.tsx
@@ -17,11 +17,12 @@ import { setAddingPersonal } from '@store/Contact/ContactActions';
 import { ContactActionTypes } from '@store/Contact/ContactTypes';
 import i18n from '@i18n';
 import Letter from '@assets/views/AddContact/Letter';
-import { setProfileOverride } from '@components/Topbar';
 import * as Segment from 'expo-analytics-segment';
-import { ContactPersonal, ContactDraft } from 'types';
+import { ContactPersonal, ContactDraft, TopbarRight } from 'types';
 import { getFacilities } from '@api';
 import { dropdownError } from '@components/Dropdown/Dropdown.react';
+import { setTopbarRight } from '@store/UI/UIActions';
+import { UIActionTypes } from '@store/UI/UITypes';
 import CommonStyles from './AddContact.styles';
 
 type ContactInfoScreenNavigationProp = StackNavigationProp<
@@ -36,6 +37,7 @@ export interface Props {
     params?: { addFromSelector?: boolean; phyState?: string };
   };
   setAddingPersonal: (contactPersonal: ContactPersonal) => void;
+  setTopbarRight: (details: TopbarRight | null) => void;
 }
 
 export interface State {
@@ -90,7 +92,7 @@ class ContactInfoScreenBase extends React.Component<Props, State> {
 
   onNavigationFocus() {
     this.loadValuesFromStore();
-    setProfileOverride({
+    this.props.setTopbarRight({
       enabled: this.state.valid,
       text: i18n.t('ContactInfoScreen.next'),
       action: this.onNextPress,
@@ -98,7 +100,7 @@ class ContactInfoScreenBase extends React.Component<Props, State> {
   }
 
   onNavigationBlur = () => {
-    setProfileOverride(undefined);
+    this.props.setTopbarRight(null);
   };
 
   onNextPress() {
@@ -128,7 +130,7 @@ class ContactInfoScreenBase extends React.Component<Props, State> {
 
   setValid(val: boolean) {
     this.setState({ valid: val });
-    setProfileOverride({
+    this.props.setTopbarRight({
       enabled: val,
       text: i18n.t('ContactInfoScreen.next'),
       action: this.onNextPress,
@@ -312,12 +314,14 @@ class ContactInfoScreenBase extends React.Component<Props, State> {
 const mapStateToProps = (state: AppState) => ({
   contactDraft: state.contact.adding,
 });
-const mapDispatchToProps = (dispatch: Dispatch<ContactActionTypes>) => {
-  return {
-    setAddingPersonal: (contactPersonal: ContactPersonal) =>
-      dispatch(setAddingPersonal(contactPersonal)),
-  };
-};
+const mapDispatchToProps = (
+  dispatch: Dispatch<ContactActionTypes | UIActionTypes>
+) => ({
+  setAddingPersonal: (contactPersonal: ContactPersonal) =>
+    dispatch(setAddingPersonal(contactPersonal)),
+  setTopbarRight: (details: TopbarRight | null) =>
+    dispatch(setTopbarRight(details)),
+});
 const ContactInfoScreen = connect(
   mapStateToProps,
   mapDispatchToProps

--- a/src/views/AddContact/ContactInfo.react.tsx
+++ b/src/views/AddContact/ContactInfo.react.tsx
@@ -57,8 +57,6 @@ class ContactInfoScreenBase extends React.Component<Props, State> {
 
   private unsubscribeFocus: () => void;
 
-  private unsubscribeBlur: () => void;
-
   private scrollView = createRef<ScrollView>();
 
   constructor(props: Props) {
@@ -73,11 +71,6 @@ class ContactInfoScreenBase extends React.Component<Props, State> {
       'focus',
       this.onNavigationFocus
     );
-    this.onNavigationBlur = this.onNavigationBlur.bind(this);
-    this.unsubscribeBlur = this.props.navigation.addListener(
-      'blur',
-      this.onNavigationBlur
-    );
     this.isExceedsNameCharLimit = this.isExceedsNameCharLimit.bind(this);
   }
 
@@ -87,7 +80,6 @@ class ContactInfoScreenBase extends React.Component<Props, State> {
 
   componentWillUnmount() {
     this.unsubscribeFocus();
-    this.unsubscribeBlur();
   }
 
   onNavigationFocus() {
@@ -98,10 +90,6 @@ class ContactInfoScreenBase extends React.Component<Props, State> {
       action: this.onNextPress,
     });
   }
-
-  onNavigationBlur = () => {
-    this.props.setTopbarRight(null);
-  };
 
   onNextPress() {
     Segment.trackWithProperties('Add Contact - Click on Next', {

--- a/src/views/AddContact/ContactInmateInfo.react.tsx
+++ b/src/views/AddContact/ContactInmateInfo.react.tsx
@@ -43,6 +43,7 @@ import {
   Validation,
 } from '@utils';
 import { setTopbarRight } from '@store/UI/UIActions';
+import { UIActionTypes } from '@store/UI/UITypes';
 import CommonStyles from './AddContact.styles';
 
 type ContactInmateInfoScreenNavigationProp = StackNavigationProp<

--- a/src/views/AddContact/ContactInmateInfo.react.tsx
+++ b/src/views/AddContact/ContactInmateInfo.react.tsx
@@ -87,8 +87,6 @@ class InmateInfoScreenBase extends React.Component<Props, State> {
 
   private unsubscribeFocus: () => void;
 
-  private unsubscribeBlur: () => void;
-
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -101,11 +99,6 @@ class InmateInfoScreenBase extends React.Component<Props, State> {
       'focus',
       this.onNavigationFocus
     );
-    this.onNavigationBlur = this.onNavigationBlur.bind(this);
-    this.unsubscribeBlur = this.props.navigation.addListener(
-      'blur',
-      this.onNavigationBlur
-    );
   }
 
   componentDidMount() {
@@ -114,7 +107,6 @@ class InmateInfoScreenBase extends React.Component<Props, State> {
 
   componentWillUnmount() {
     this.unsubscribeFocus();
-    this.unsubscribeBlur();
   }
 
   onNavigationFocus() {
@@ -125,10 +117,6 @@ class InmateInfoScreenBase extends React.Component<Props, State> {
       action: this.onNextPress,
     });
   }
-
-  onNavigationBlur = () => {
-    this.props.setTopbarRight(null);
-  };
 
   onNextPress() {
     Segment.trackWithProperties('Add Contact - Click on Next', {

--- a/src/views/AddContact/ContactInmateInfo.react.tsx
+++ b/src/views/AddContact/ContactInmateInfo.react.tsx
@@ -30,11 +30,11 @@ import {
   ContactInmateInfo,
   Facility,
   PrisonTypes,
+  TopbarRight,
 } from 'types';
 import { ContactActionTypes } from '@store/Contact/ContactTypes';
 import { AppState } from '@store/types';
 import * as Segment from 'expo-analytics-segment';
-import { setProfileOverride } from '@components/Topbar';
 
 import {
   STATES_DROPDOWN,
@@ -42,6 +42,7 @@ import {
   STATE_TO_INMATE_DB,
   Validation,
 } from '@utils';
+import { setTopbarRight } from '@store/UI/UIActions';
 import CommonStyles from './AddContact.styles';
 
 type ContactInmateInfoScreenNavigationProp = StackNavigationProp<
@@ -55,6 +56,7 @@ export interface Props {
   route: { params: { manual: boolean; prisonType: PrisonTypes } };
   setAddingInmateInfo: (contactInmateInfo: ContactInmateInfo) => void;
   setAddingFacility: (contactFacility: ContactFacility) => void;
+  setTopbarRight: (details: TopbarRight | null) => void;
 }
 
 export interface State {
@@ -116,7 +118,7 @@ class InmateInfoScreenBase extends React.Component<Props, State> {
 
   onNavigationFocus() {
     this.loadValuesFromStore();
-    setProfileOverride({
+    this.props.setTopbarRight({
       enabled: this.state.valid,
       text: i18n.t('ContactInmateInfoScreen.next'),
       action: this.onNextPress,
@@ -124,7 +126,7 @@ class InmateInfoScreenBase extends React.Component<Props, State> {
   }
 
   onNavigationBlur = () => {
-    setProfileOverride(undefined);
+    this.props.setTopbarRight(null);
   };
 
   onNextPress() {
@@ -220,7 +222,7 @@ class InmateInfoScreenBase extends React.Component<Props, State> {
 
   setValid(val: boolean) {
     this.setState({ valid: val });
-    setProfileOverride({
+    this.props.setTopbarRight({
       enabled: val,
       text: i18n.t('ContactInmateInfoScreen.next'),
       action: this.onNextPress,
@@ -469,12 +471,16 @@ class InmateInfoScreenBase extends React.Component<Props, State> {
 const mapStateToProps = (state: AppState) => ({
   contactDraft: state.contact.adding,
 });
-const mapDispatchToProps = (dispatch: Dispatch<ContactActionTypes>) => {
+const mapDispatchToProps = (
+  dispatch: Dispatch<ContactActionTypes | UIActionTypes>
+) => {
   return {
     setAddingInmateInfo: (contactInmateInfo: ContactInmateInfo) =>
       dispatch(setAddingInmateInfo(contactInmateInfo)),
     setAddingFacility: (contactFacility: ContactFacility) =>
       dispatch(setAddingFacility(contactFacility)),
+    setTopbarRight: (details: TopbarRight | null) =>
+      dispatch(setTopbarRight(details)),
   };
 };
 const ContactInmateInfoScreen = connect(

--- a/src/views/AddContact/FacilityDirectory.react.tsx
+++ b/src/views/AddContact/FacilityDirectory.react.tsx
@@ -47,8 +47,6 @@ export interface State {
 class FacilityDirectoryScreenBase extends React.Component<Props, State> {
   private unsubscribeFocus: () => void;
 
-  private unsubscribeBlur: () => void;
-
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -67,11 +65,6 @@ class FacilityDirectoryScreenBase extends React.Component<Props, State> {
       'focus',
       this.onNavigationFocus
     );
-    this.onNavigationBlur = this.onNavigationBlur.bind(this);
-    this.unsubscribeBlur = this.props.navigation.addListener(
-      'blur',
-      this.onNavigationBlur
-    );
   }
 
   async componentDidMount() {
@@ -80,12 +73,7 @@ class FacilityDirectoryScreenBase extends React.Component<Props, State> {
 
   componentWillUnmount() {
     this.unsubscribeFocus();
-    this.unsubscribeBlur();
   }
-
-  onNavigationBlur = () => {
-    this.props.setTopbarRight(null);
-  };
 
   onNavigationFocus() {
     if (!this.props.facilityState.loaded) {

--- a/src/views/AddContact/FacilityDirectory.react.tsx
+++ b/src/views/AddContact/FacilityDirectory.react.tsx
@@ -4,7 +4,7 @@ import { Colors, Typography } from '@styles';
 import { AppStackParamList, Screens } from '@utils/Screens';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { Button, Input, Icon, KeyboardAvoider } from '@components';
-import { Facility, ContactFacility, PrisonTypes } from 'types';
+import { Facility, ContactFacility, PrisonTypes, TopbarRight } from 'types';
 import { connect } from 'react-redux';
 import { AppState } from '@store/types';
 import { setAddingFacility } from '@store/Contact/ContactActions';
@@ -14,9 +14,10 @@ import FacilityIcon from '@assets/views/AddContact/Facility';
 import { getFacilities } from '@api';
 import { STATE_TO_ABBREV } from '@utils';
 import { dropdownError } from '@components/Dropdown/Dropdown.react';
-import { setProfileOverride } from '@components/Topbar';
 import * as Segment from 'expo-analytics-segment';
 import { FacilityState } from '@store/Facility/FacilityTypes';
+import { setTopbarRight } from '@store/UI/UIActions';
+import { UIActionTypes } from '@store/UI/UITypes';
 import Styles from './FacilityDirectory.styles';
 
 type ContactInfoScreenNavigationProp = StackNavigationProp<
@@ -31,6 +32,7 @@ export interface Props {
   };
   contactState: ContactState;
   setAddingFacility: (contactFacility: ContactFacility) => void;
+  setTopbarRight: (details: TopbarRight | null) => void;
   facilityState: FacilityState;
 }
 
@@ -82,7 +84,7 @@ class FacilityDirectoryScreenBase extends React.Component<Props, State> {
   }
 
   onNavigationBlur = () => {
-    setProfileOverride(undefined);
+    this.props.setTopbarRight(null);
   };
 
   onNavigationFocus() {
@@ -90,7 +92,7 @@ class FacilityDirectoryScreenBase extends React.Component<Props, State> {
       this.refreshFacilities();
     }
     this.loadValuesFromStore();
-    setProfileOverride({
+    this.props.setTopbarRight({
       enabled: this.state.selected !== null,
       text: i18n.t('ContactInfoScreen.next'),
       action: () => {
@@ -108,7 +110,7 @@ class FacilityDirectoryScreenBase extends React.Component<Props, State> {
   }
 
   setValid(val: boolean) {
-    setProfileOverride({
+    this.props.setTopbarRight({
       enabled: val,
       text: i18n.t('ContactInfoScreen.next'),
       action: () => {
@@ -319,12 +321,14 @@ const mapStateToProps = (state: AppState) => ({
   contactState: state.contact,
   facilityState: state.facility,
 });
-const mapDispatchToProps = (dispatch: Dispatch<ContactActionTypes>) => {
-  return {
-    setAddingFacility: (contactFacility: ContactFacility) =>
-      dispatch(setAddingFacility(contactFacility)),
-  };
-};
+const mapDispatchToProps = (
+  dispatch: Dispatch<ContactActionTypes | UIActionTypes>
+) => ({
+  setAddingFacility: (contactFacility: ContactFacility) =>
+    dispatch(setAddingFacility(contactFacility)),
+  setTopbarRight: (details: TopbarRight | null) =>
+    dispatch(setTopbarRight(details)),
+});
 const FacilityDirectoryScreen = connect(
   mapStateToProps,
   mapDispatchToProps

--- a/src/views/Compose/ComposeLetter.react.tsx
+++ b/src/views/Compose/ComposeLetter.react.tsx
@@ -22,13 +22,14 @@ import { AppState } from '@store/types';
 import { setContent, setImages } from '@store/Mail/MailActions';
 import { MailActionTypes } from '@store/Mail/MailTypes';
 import i18n from '@i18n';
-import { Draft, Image, MailTypes } from 'types';
+import { Draft, Image, MailTypes, TopbarRight } from 'types';
 import { PicUploadTypes } from '@components/PicUpload/PicUpload.react';
-import { setProfileOverride } from '@components/Topbar';
 import { popupAlert } from '@components/Alert/Alert.react';
 import { getNumWords } from '@utils';
 import * as Segment from 'expo-analytics-segment';
 import { saveDraft } from '@api';
+import { setTopbarRight } from '@store/UI/UIActions';
+import { UIActionTypes } from '@store/UI/UITypes';
 import Styles, { LETTER_COMPOSE_IMAGE_HEIGHT } from './Compose.styles';
 
 type ComposeLetterScreenNavigationProp = StackNavigationProp<
@@ -44,6 +45,7 @@ interface Props {
   setContent: (content: string) => void;
   setImages: (images: Image[]) => void;
   credits: number;
+  setTopbarRight: (details: TopbarRight | null) => void;
 }
 
 interface State {
@@ -130,7 +132,7 @@ class ComposeLetterScreenBase extends React.Component<Props, State> {
 
     if (this.textRef.current) this.textRef.current.focus();
 
-    setProfileOverride({
+    this.props.setTopbarRight({
       enabled: this.state.valid,
       text: i18n.t('Compose.next'),
       action: this.onNextPress,
@@ -161,7 +163,7 @@ class ComposeLetterScreenBase extends React.Component<Props, State> {
   }
 
   onNavigationBlur = () => {
-    setProfileOverride(undefined);
+    this.props.setTopbarRight(null);
   };
 
   onKeyboardOpen() {
@@ -185,7 +187,7 @@ class ComposeLetterScreenBase extends React.Component<Props, State> {
   setValid(val: boolean) {
     if (val === this.state.valid) return;
     this.setState({ valid: val });
-    setProfileOverride({
+    this.props.setTopbarRight({
       enabled: val,
       text: i18n.t('Compose.next'),
       action: this.onNextPress,
@@ -377,12 +379,14 @@ const mapStateToProps = (state: AppState) => ({
   credits: state.user.user.credit,
 });
 
-const mapDispatchToProps = (dispatch: Dispatch<MailActionTypes>) => {
-  return {
-    setContent: (content: string) => dispatch(setContent(content)),
-    setImages: (images: Image[]) => dispatch(setImages(images)),
-  };
-};
+const mapDispatchToProps = (
+  dispatch: Dispatch<MailActionTypes | UIActionTypes>
+) => ({
+  setContent: (content: string) => dispatch(setContent(content)),
+  setImages: (images: Image[]) => dispatch(setImages(images)),
+  setTopbarRight: (details: TopbarRight | null) =>
+    dispatch(setTopbarRight(details)),
+});
 const ComposeLetterScreen = connect(
   mapStateToProps,
   mapDispatchToProps

--- a/src/views/Compose/ComposeLetter.react.tsx
+++ b/src/views/Compose/ComposeLetter.react.tsx
@@ -64,8 +64,6 @@ class ComposeLetterScreenBase extends React.Component<Props, State> {
 
   private unsubscribeFocus: () => void;
 
-  private unsubscribeBlur: () => void;
-
   private unsubscribeKeyboardOpen: EmitterSubscription;
 
   private unsubscribeKeyboardClose: EmitterSubscription;
@@ -92,10 +90,6 @@ class ComposeLetterScreenBase extends React.Component<Props, State> {
       'focus',
       this.onNavigationFocus
     );
-    this.unsubscribeBlur = this.props.navigation.addListener(
-      'blur',
-      this.onNavigationBlur
-    );
     this.unsubscribeKeyboardOpen = Keyboard.addListener(
       Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow',
       this.onKeyboardOpen
@@ -108,7 +102,6 @@ class ComposeLetterScreenBase extends React.Component<Props, State> {
 
   componentWillUnmount() {
     this.unsubscribeFocus();
-    this.unsubscribeBlur();
     this.unsubscribeKeyboardOpen.remove();
     this.unsubscribeKeyboardClose.remove();
   }
@@ -161,10 +154,6 @@ class ComposeLetterScreenBase extends React.Component<Props, State> {
       this.props.navigation.navigate(Screens.ReviewLetter);
     }
   }
-
-  onNavigationBlur = () => {
-    this.props.setTopbarRight(null);
-  };
 
   onKeyboardOpen() {
     Animated.timing(this.state.keyboardOpacity, {

--- a/src/views/Compose/ComposePersonal.react.tsx
+++ b/src/views/Compose/ComposePersonal.react.tsx
@@ -30,8 +30,9 @@ import {
   Font,
   DraftPostcard,
   PersonalDesign,
+  TopbarRight,
+  TopbarLeft,
 } from 'types';
-import { setBackOverride, setProfileOverride } from '@components/Topbar';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { AppStackParamList, Screens } from '@utils/Screens';
 import i18n from '@i18n';
@@ -52,7 +53,6 @@ import {
   PERSONAL_OVERRIDE_ID,
   DESIGN_BUTTONS_HEIGHT,
   BOTTOM_HEIGHT,
-  TRAY_CLOSED,
   BUTTONS_HIDDEN,
   FLIP_DURATION,
   KEYBOARD_HIDDEN,
@@ -68,6 +68,8 @@ import {
   showKeyboardItem,
   unflip,
 } from '@utils/Animations';
+import { setTopbarLeft, setTopbarRight } from '@store/UI/UIActions';
+import { UIActionTypes } from '@store/UI/UITypes';
 import Styles from './Compose.styles';
 
 type ComposePersonalScreenNavigationProp = StackNavigationProp<
@@ -83,6 +85,8 @@ interface Props {
   setContent: (content: string) => void;
   setFont: (font: Font) => void;
   setDesign: (design: PersonalDesign) => void;
+  setTopbarRight: (details: TopbarRight | null) => void;
+  setTopbarLeft: (details: TopbarLeft | null) => void;
 }
 
 interface State {
@@ -244,10 +248,10 @@ class ComposePersonalScreenBase extends React.Component<Props, State> {
       }
     }
     if (this.state.subscreen === 'Text') {
-      setBackOverride({
+      this.props.setTopbarLeft({
         action: this.backWriting,
       });
-      setProfileOverride({
+      this.props.setTopbarRight({
         enabled: true,
         text: i18n.t('Compose.done'),
         action: this.doneWriting,
@@ -256,8 +260,8 @@ class ComposePersonalScreenBase extends React.Component<Props, State> {
   }
 
   onNavigationBlur = () => {
-    setBackOverride(undefined);
-    setProfileOverride(undefined);
+    this.props.setTopbarLeft(null);
+    this.props.setTopbarRight(null);
   };
 
   onKeyboardOpen(): void {
@@ -432,10 +436,10 @@ class ComposePersonalScreenBase extends React.Component<Props, State> {
     showButtons(this.state.textState.buttonSlide, undefined, {
       duration: FLIP_DURATION,
     });
-    setBackOverride({
+    this.props.setTopbarLeft({
       action: this.backWriting,
     });
-    setProfileOverride({
+    this.props.setTopbarRight({
       enabled: true,
       text: i18n.t('Compose.done'),
       action: this.doneWriting,
@@ -450,8 +454,8 @@ class ComposePersonalScreenBase extends React.Component<Props, State> {
     hideButtons(this.state.textState.buttonSlide);
     this.closeTextBottom();
     this.setDesignState({ animatingFlip: true });
-    setBackOverride(undefined);
-    setProfileOverride(undefined);
+    this.props.setTopbarLeft(null);
+    this.props.setTopbarRight(null);
   }
 
   doneWriting(): void {
@@ -682,10 +686,16 @@ const mapStateToProps = (state: AppState) => ({
   recipient: state.contact.active,
 });
 
-const mapDisptatchToProps = (dispatch: Dispatch<MailActionTypes>) => ({
+const mapDisptatchToProps = (
+  dispatch: Dispatch<MailActionTypes | UIActionTypes>
+) => ({
   setContent: (content: string) => dispatch(setContent(content)),
   setFont: (font: Font) => dispatch(setFont(font)),
   setDesign: (design: PersonalDesign) => dispatch(setDesign(design)),
+  setTopbarRight: (details: TopbarRight | null) =>
+    dispatch(setTopbarRight(details)),
+  setTopbarLeft: (details: TopbarLeft | null) =>
+    dispatch(setTopbarLeft(details)),
 });
 
 const ComposePersonalScreen = connect(

--- a/src/views/Compose/ComposePersonal.react.tsx
+++ b/src/views/Compose/ComposePersonal.react.tsx
@@ -122,8 +122,6 @@ interface State {
 class ComposePersonalScreenBase extends React.Component<Props, State> {
   private unsubscribeFocus: () => void;
 
-  private unsubscribeBlur: () => void;
-
   private unsubscribeKeyboardOpen: EmitterSubscription;
 
   private unsubscribeKeyboardClose: EmitterSubscription;
@@ -171,7 +169,6 @@ class ComposePersonalScreenBase extends React.Component<Props, State> {
     };
 
     this.onNavigationFocus = this.onNavigationFocus.bind(this);
-    this.onNavigationBlur = this.onNavigationBlur.bind(this);
     this.onKeyboardOpen = this.onKeyboardOpen.bind(this);
     this.onKeyboardClose = this.onKeyboardClose.bind(this);
     this.openDesignBottom = this.openDesignBottom.bind(this);
@@ -188,10 +185,6 @@ class ComposePersonalScreenBase extends React.Component<Props, State> {
       'focus',
       this.onNavigationFocus
     );
-    this.unsubscribeBlur = this.props.navigation.addListener(
-      'blur',
-      this.onNavigationBlur
-    );
     this.unsubscribeKeyboardOpen = Keyboard.addListener(
       Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow',
       this.onKeyboardOpen
@@ -204,7 +197,6 @@ class ComposePersonalScreenBase extends React.Component<Props, State> {
 
   componentWillUnmount() {
     this.unsubscribeFocus();
-    this.unsubscribeBlur();
     this.unsubscribeKeyboardOpen.remove();
     this.unsubscribeKeyboardClose.remove();
   }
@@ -258,11 +250,6 @@ class ComposePersonalScreenBase extends React.Component<Props, State> {
       });
     }
   }
-
-  onNavigationBlur = () => {
-    this.props.setTopbarLeft(null);
-    this.props.setTopbarRight(null);
-  };
 
   onKeyboardOpen(): void {
     this.setTextState({ writing: true }, () => {

--- a/src/views/Compose/ComposePostcard.react.tsx
+++ b/src/views/Compose/ComposePostcard.react.tsx
@@ -130,8 +130,6 @@ class ComposePostcardScreenBase extends React.Component<Props, State> {
 
   private unsubscribeFocus: () => void;
 
-  private unsubscribeBlur: () => void;
-
   private unsubscribeKeyboardOpen: EmitterSubscription;
 
   private unsubscribeKeyboardClose: EmitterSubscription;
@@ -187,10 +185,6 @@ class ComposePostcardScreenBase extends React.Component<Props, State> {
       'focus',
       this.onNavigationFocus
     );
-    this.unsubscribeBlur = this.props.navigation.addListener(
-      'blur',
-      this.onNavigationBlur
-    );
 
     this.unsubscribeKeyboardOpen = Keyboard.addListener(
       Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow',
@@ -229,7 +223,6 @@ class ComposePostcardScreenBase extends React.Component<Props, State> {
 
   componentWillUnmount(): void {
     this.unsubscribeFocus();
-    this.unsubscribeBlur();
     this.unsubscribeKeyboardOpen.remove();
     this.unsubscribeKeyboardClose.remove();
   }
@@ -293,11 +286,6 @@ class ComposePostcardScreenBase extends React.Component<Props, State> {
         this.props.route.params.category.subcategories
       )[0],
     });
-  };
-
-  onNavigationBlur = (): void => {
-    this.props.setTopbarLeft(null);
-    this.props.setTopbarRight(null);
   };
 
   onKeyboardOpen(): void {
@@ -711,7 +699,7 @@ class ComposePostcardScreenBase extends React.Component<Props, State> {
               {this.renderSubcategorySelector()}
 
               <FlatList
-                data={data.reverse()}
+                data={data}
                 renderItem={({ item }) => this.renderItem(item)}
                 keyExtractor={(item: PremadePostcardDesign, index: number) => {
                   return item.asset.uri + index.toString();

--- a/src/views/Compose/ComposePostcard.react.tsx
+++ b/src/views/Compose/ComposePostcard.react.tsx
@@ -29,6 +29,8 @@ import {
   CustomFontFamilies,
   DraftPostcard,
   PremadePostcardDesign,
+  TopbarRight,
+  TopbarLeft,
 } from 'types';
 import { Typography, Colors } from '@styles';
 import {
@@ -38,7 +40,6 @@ import {
   getImageDims,
   getPostcardDesignImage,
 } from '@utils';
-import { setBackOverride, setProfileOverride } from '@components/Topbar';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { AppStackParamList, Screens } from '@utils/Screens';
 import i18n from '@i18n';
@@ -72,6 +73,8 @@ import {
 import { CategoryActionTypes } from '@store/Category/CategoryTypes';
 import CardStyles from '@components/Card/Card.styles';
 import { setDesignImage } from '@store/Category/CategoryActions';
+import { setTopbarLeft, setTopbarRight } from '@store/UI/UIActions';
+import { UIActionTypes } from '@store/UI/UITypes';
 import Styles from './Compose.styles';
 
 type ComposePostcardScreenNavigationProp = StackNavigationProp<
@@ -99,6 +102,8 @@ interface Props {
     designId: number,
     image: Image
   ) => void;
+  setTopbarRight: (details: TopbarRight | null) => void;
+  setTopbarLeft: (details: TopbarLeft | null) => void;
 }
 
 interface State {
@@ -198,7 +203,7 @@ class ComposePostcardScreenBase extends React.Component<Props, State> {
   }
 
   async componentDidMount(): Promise<void> {
-    setProfileOverride({
+    this.props.setTopbarRight({
       enabled: true,
       text: 'Next',
       action: this.beginWriting,
@@ -265,18 +270,18 @@ class ComposePostcardScreenBase extends React.Component<Props, State> {
     }
 
     if (!this.state.writing) {
-      setProfileOverride({
+      this.props.setTopbarRight({
         enabled: true,
         text: 'Next',
         action: this.beginWriting,
       });
     } else {
-      setBackOverride({
+      this.props.setTopbarLeft({
         action: () => {
           this.backWriting();
         },
       });
-      setProfileOverride({
+      this.props.setTopbarRight({
         enabled: this.state.valid,
         text: i18n.t('Compose.done'),
         action: this.doneWriting,
@@ -291,8 +296,8 @@ class ComposePostcardScreenBase extends React.Component<Props, State> {
   };
 
   onNavigationBlur = (): void => {
-    setBackOverride(undefined);
-    setProfileOverride(undefined);
+    this.props.setTopbarLeft(null);
+    this.props.setTopbarRight(null);
   };
 
   onKeyboardOpen(): void {
@@ -310,7 +315,7 @@ class ComposePostcardScreenBase extends React.Component<Props, State> {
     if (val !== this.state.valid) {
       this.setState({ valid: val });
       if (this.state.writing) {
-        setProfileOverride({
+        this.props.setTopbarRight({
           enabled: val,
           text: i18n.t('Compose.done'),
           action: this.doneWriting,
@@ -386,14 +391,14 @@ class ComposePostcardScreenBase extends React.Component<Props, State> {
       });
       return;
     }
-    setProfileOverride({
+    this.props.setTopbarRight({
       enabled: true,
       text: i18n.t('Compose.done'),
       action: this.doneWriting,
     });
     flip(this.state.flip, () => {
       this.setState({ writing: true });
-      setBackOverride({
+      this.props.setTopbarLeft({
         action: () => {
           this.backWriting();
         },
@@ -405,7 +410,7 @@ class ComposePostcardScreenBase extends React.Component<Props, State> {
 
   backWriting(): void {
     Keyboard.dismiss();
-    setBackOverride(undefined);
+    this.props.setTopbarLeft(null);
     this.changeDesign(this.state.design);
     this.setState({ horizontal: this.designIsHorizontal() });
     Segment.trackWithProperties('Compose - Click on Back', {
@@ -414,7 +419,7 @@ class ComposePostcardScreenBase extends React.Component<Props, State> {
     });
     unflip(this.state.flip, () => {
       this.setState({ writing: false });
-      setProfileOverride({
+      this.props.setTopbarRight({
         enabled: true,
         text: i18n.t('Compose.next'),
         action: () => {
@@ -737,7 +742,7 @@ const mapStateToProps = (state: AppState) => ({
 });
 
 const mapDispatchToProps = (
-  dispatch: Dispatch<MailActionTypes | CategoryActionTypes>
+  dispatch: Dispatch<MailActionTypes | CategoryActionTypes | UIActionTypes>
 ) => ({
   setContent: (content: string) => dispatch(setContent(content)),
   setFont: (font: Font) => dispatch(setFont(font)),
@@ -748,6 +753,10 @@ const mapDispatchToProps = (
     designId: number,
     image: Image
   ) => dispatch(setDesignImage(categoryId, subcategoryName, designId, image)),
+  setTopbarRight: (details: TopbarRight | null) =>
+    dispatch(setTopbarRight(details)),
+  setTopbarLeft: (details: TopbarLeft | null) =>
+    dispatch(setTopbarLeft(details)),
 });
 
 const ComposePostcardScreen = connect(

--- a/src/views/Compose/ReferFriends.react.tsx
+++ b/src/views/Compose/ReferFriends.react.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { Dispatch, useEffect } from 'react';
 import { Text, View, Platform, ScrollView } from 'react-native';
 import { Button, KeyboardAvoider } from '@components';
 import { Typography } from '@styles';
@@ -14,10 +14,11 @@ import PostcardLottie from '@assets/views/ReferFriends/Postcard.json';
 import Icon from '@components/Icon/Icon.react';
 import Truck from '@assets/views/ReferFriends/Truck';
 import { differenceInBusinessDays, format } from 'date-fns';
-import { Contact, MailTypes } from 'types';
+import { Contact, MailTypes, TopbarRight } from 'types';
 import { onNativeShare, estimateDelivery, requestReview } from '@utils';
 
-import { setProfileOverride } from '@components/Topbar';
+import { UIActionTypes } from '@store/UI/UITypes';
+import { setTopbarRight } from '@store/UI/UIActions';
 import Styles from './ReferFriends.style';
 
 type ReferFriendsScreenNavigationProp = StackNavigationProp<
@@ -34,6 +35,7 @@ export interface Props {
   route: {
     params: { mailType: MailTypes };
   };
+  setTopbarRight: (details: TopbarRight | null) => void;
 }
 
 const ReferFriendsScreenBase: React.FC<Props> = (props: Props) => {
@@ -45,7 +47,7 @@ const ReferFriendsScreenBase: React.FC<Props> = (props: Props) => {
     ) {
       requestReview();
     }
-    setProfileOverride(undefined);
+    props.setTopbarRight(null);
   }, []);
 
   const genLottieView = () => {
@@ -151,17 +153,22 @@ const ReferFriendsScreenBase: React.FC<Props> = (props: Props) => {
   );
 };
 
-const mapStateToProps = (state: AppState) => {
-  return {
-    contact: state.contact.active,
-    referralCode: state.user.user.referralCode,
-    numMailSent: Object.keys(state.mail.existing)
-      .map((key) => state.mail.existing[key].length)
-      .reduce((acc, curr) => acc + curr, 0),
-    joined: state.user.user.joined,
-  };
-};
+const mapStateToProps = (state: AppState) => ({
+  contact: state.contact.active,
+  referralCode: state.user.user.referralCode,
+  numMailSent: Object.keys(state.mail.existing)
+    .map((key) => state.mail.existing[key].length)
+    .reduce((acc, curr) => acc + curr, 0),
+  joined: state.user.user.joined,
+});
+const mapDispatchToProps = (dispatch: Dispatch<UIActionTypes>) => ({
+  setTopbarRight: (details: TopbarRight | null) =>
+    dispatch(setTopbarRight(details)),
+});
 
-const ReferFriendsScreen = connect(mapStateToProps)(ReferFriendsScreenBase);
+const ReferFriendsScreen = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ReferFriendsScreenBase);
 
 export default ReferFriendsScreen;

--- a/src/views/Compose/ReferFriends.react.tsx
+++ b/src/views/Compose/ReferFriends.react.tsx
@@ -47,7 +47,6 @@ const ReferFriendsScreenBase: React.FC<Props> = (props: Props) => {
     ) {
       requestReview();
     }
-    props.setTopbarRight(null);
   }, []);
 
   const genLottieView = () => {

--- a/src/views/Compose/ReviewLetter.react.tsx
+++ b/src/views/Compose/ReviewLetter.react.tsx
@@ -5,7 +5,7 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import { AppStackParamList, Screens } from '@utils/Screens';
 import { connect } from 'react-redux';
 import { AppState } from '@store/types';
-import { Draft, MailTypes, Contact } from 'types';
+import { Draft, MailTypes, Contact, TopbarRight } from 'types';
 import { Typography, Colors } from '@styles';
 import { clearComposing } from '@store/Mail/MailActions';
 import { createMail } from '@api';
@@ -14,8 +14,9 @@ import i18n from '@i18n';
 import { MailActionTypes } from '@store/Mail/MailTypes';
 import { cleanupAfterSend } from '@utils/Notifications';
 import * as Segment from 'expo-analytics-segment';
-import { setProfileOverride } from '@components/Topbar';
 import { popupAlert } from '@components/Alert/Alert.react';
+import { setTopbarRight } from '@store/UI/UIActions';
+import { UIActionTypes } from '@store/UI/UITypes';
 import Styles from './Compose.styles';
 
 type ReviewLetterScreenNavigationProp = StackNavigationProp<
@@ -29,6 +30,7 @@ interface Props {
   composing: Draft;
   clearComposing: () => void;
   ameelioBalance: number;
+  setTopbarRight: (details: TopbarRight | null) => void;
 }
 
 class ReviewLetterScreenBase extends React.Component<Props> {
@@ -55,7 +57,7 @@ class ReviewLetterScreenBase extends React.Component<Props> {
   }
 
   onNavigationFocus = (): void => {
-    setProfileOverride({
+    this.props.setTopbarRight({
       text: i18n.t('Compose.send'),
       action: this.doSend,
       enabled: true,
@@ -64,7 +66,7 @@ class ReviewLetterScreenBase extends React.Component<Props> {
   };
 
   onNavigationBlur = (): void => {
-    setProfileOverride(undefined);
+    this.props.setTopbarRight(null);
   };
 
   async doSend() {
@@ -200,8 +202,12 @@ const mapStateToProps = (state: AppState) => ({
   activeContact: state.contact.active,
   ameelioBalance: state.user.user.credit,
 });
-const mapDispatchToProps = (dispatch: Dispatch<MailActionTypes>) => ({
+const mapDispatchToProps = (
+  dispatch: Dispatch<MailActionTypes | UIActionTypes>
+) => ({
   clearComposing: () => dispatch(clearComposing()),
+  setTopbarRight: (details: TopbarRight | null) =>
+    dispatch(setTopbarRight(details)),
 });
 const LetterPreviewScreen = connect(
   mapStateToProps,

--- a/src/views/Compose/ReviewLetter.react.tsx
+++ b/src/views/Compose/ReviewLetter.react.tsx
@@ -36,8 +36,6 @@ interface Props {
 class ReviewLetterScreenBase extends React.Component<Props> {
   private unsubscribeFocus: () => void;
 
-  private unsubscribeBlur: () => void;
-
   constructor(props: Props) {
     super(props);
     this.doSend = this.doSend.bind(this);
@@ -45,15 +43,10 @@ class ReviewLetterScreenBase extends React.Component<Props> {
       'focus',
       this.onNavigationFocus
     );
-    this.unsubscribeBlur = props.navigation.addListener(
-      'blur',
-      this.onNavigationBlur
-    );
   }
 
   componentWillUnmount() {
     this.unsubscribeFocus();
-    this.unsubscribeBlur();
   }
 
   onNavigationFocus = (): void => {
@@ -63,10 +56,6 @@ class ReviewLetterScreenBase extends React.Component<Props> {
       enabled: true,
       blocking: true,
     });
-  };
-
-  onNavigationBlur = (): void => {
-    this.props.setTopbarRight(null);
   };
 
   async doSend() {

--- a/src/views/Compose/ReviewPostcard.react.tsx
+++ b/src/views/Compose/ReviewPostcard.react.tsx
@@ -9,7 +9,13 @@ import {
 import { ReviewCredits, StaticPostcard } from '@components';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { AppStackParamList, Screens } from '@utils/Screens';
-import { Draft, Contact, MailTypes, CustomFontFamilies } from 'types';
+import {
+  Draft,
+  Contact,
+  MailTypes,
+  CustomFontFamilies,
+  TopbarRight,
+} from 'types';
 import { AppState } from '@store/types';
 import { connect } from 'react-redux';
 import { createMail } from '@api';
@@ -22,6 +28,8 @@ import { clearComposing } from '@store/Mail/MailActions';
 import { Typography, Colors } from '@styles';
 import { POSTCARD_HEIGHT, POSTCARD_WIDTH } from '@utils/Constants';
 import { popupAlert } from '@components/Alert/Alert.react';
+import { setTopbarRight } from '@store/UI/UIActions';
+import { UIActionTypes } from '@store/UI/UITypes';
 import Styles from './Compose.styles';
 
 type ReviewPostcardScreenNavigationProp = StackNavigationProp<
@@ -42,6 +50,7 @@ export interface Props {
   };
   ameelioBalance: number;
   plusBalance: number;
+  setTopbarRight: (details: TopbarRight | null) => void;
 }
 
 class ReviewPostcardScreenBase extends React.Component<Props> {
@@ -68,7 +77,7 @@ class ReviewPostcardScreenBase extends React.Component<Props> {
   }
 
   onNavigationFocus = (): void => {
-    setProfileOverride({
+    this.props.setTopbarRight({
       text: i18n.t('Compose.send'),
       action: this.doSend,
       enabled: true,
@@ -77,7 +86,7 @@ class ReviewPostcardScreenBase extends React.Component<Props> {
   };
 
   onNavigationBlur = (): void => {
-    setProfileOverride(undefined);
+    this.props.setTopbarRight(null);
   };
 
   async doSend(): Promise<void> {
@@ -251,8 +260,12 @@ const mapStateToProps = (state: AppState) => ({
   plusBalance: state.user.user.coins,
 });
 
-const mapDispatchToProps = (dispatch: Dispatch<MailActionTypes>) => ({
+const mapDispatchToProps = (
+  dispatch: Dispatch<MailActionTypes | UIActionTypes>
+) => ({
   clearComposing: () => dispatch(clearComposing()),
+  setTopbarRight: (details: TopbarRight | null) =>
+    dispatch(setTopbarRight(details)),
 });
 
 const ReviewPostcardScreen = connect(

--- a/src/views/Compose/ReviewPostcard.react.tsx
+++ b/src/views/Compose/ReviewPostcard.react.tsx
@@ -56,8 +56,6 @@ export interface Props {
 class ReviewPostcardScreenBase extends React.Component<Props> {
   private unsubscribeFocus: () => void;
 
-  private unsubscribeBlur: () => void;
-
   constructor(props: Props) {
     super(props);
     this.doSend = this.doSend.bind(this);
@@ -65,15 +63,10 @@ class ReviewPostcardScreenBase extends React.Component<Props> {
       'focus',
       this.onNavigationFocus
     );
-    this.unsubscribeBlur = props.navigation.addListener(
-      'blur',
-      this.onNavigationBlur
-    );
   }
 
   componentWillUnmount() {
     this.unsubscribeFocus();
-    this.unsubscribeBlur();
   }
 
   onNavigationFocus = (): void => {
@@ -83,10 +76,6 @@ class ReviewPostcardScreenBase extends React.Component<Props> {
       enabled: true,
       blocking: true,
     });
-  };
-
-  onNavigationBlur = (): void => {
-    this.props.setTopbarRight(null);
   };
 
   async doSend(): Promise<void> {

--- a/src/views/Compose/ReviewPostcard.react.tsx
+++ b/src/views/Compose/ReviewPostcard.react.tsx
@@ -9,7 +9,7 @@ import {
 import { ReviewCredits, StaticPostcard } from '@components';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { AppStackParamList, Screens } from '@utils/Screens';
-import { Draft, Contact, MailTypes, CustomFontFamilies, Font } from 'types';
+import { Draft, Contact, MailTypes, CustomFontFamilies } from 'types';
 import { AppState } from '@store/types';
 import { connect } from 'react-redux';
 import { createMail } from '@api';
@@ -19,7 +19,6 @@ import i18n from '@i18n';
 import { dropdownError } from '@components/Dropdown/Dropdown.react';
 import { MailActionTypes } from '@store/Mail/MailTypes';
 import { clearComposing } from '@store/Mail/MailActions';
-import { setProfileOverride } from '@components/Topbar';
 import { Typography, Colors } from '@styles';
 import { POSTCARD_HEIGHT, POSTCARD_WIDTH } from '@utils/Constants';
 import { popupAlert } from '@components/Alert/Alert.react';

--- a/src/views/Compose/SelectPostcardSize.react.tsx
+++ b/src/views/Compose/SelectPostcardSize.react.tsx
@@ -92,10 +92,6 @@ const SelectPostcardSizeBase = ({
         action: updatePostcardOption,
         blocking: true,
       });
-
-      return () => {
-        setTopbarRight(null);
-      };
     }, [])
   );
 

--- a/src/views/Compose/SelectPostcardSize.react.tsx
+++ b/src/views/Compose/SelectPostcardSize.react.tsx
@@ -4,11 +4,16 @@ import { View, Text, TouchableOpacity } from 'react-native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { AppStackParamList, Screens } from '@utils/Screens';
 import CardStyles from '@components/Card/Card.styles';
-import { Category, Draft, DraftPostcard, PostcardSizeOption } from 'types';
+import {
+  Category,
+  Draft,
+  DraftPostcard,
+  PostcardSizeOption,
+  TopbarRight,
+} from 'types';
 import i18n from '@i18n';
 import { Typography } from '@styles';
 import { POSTCARD_SIZE_OPTIONS } from '@utils/Constants';
-import { setProfileOverride } from '@components/Topbar';
 import { connect } from 'react-redux';
 import { setComposing } from '@store/Mail/MailActions';
 import { MailActionTypes } from '@store/Mail/MailTypes';
@@ -16,6 +21,8 @@ import { AppState } from '@store/types';
 import { FlatList } from 'react-native-gesture-handler';
 import { useFocusEffect } from '@react-navigation/native';
 import { popupAlert } from '@components/Alert/Alert.react';
+import { setTopbarRight as setTopbarRightImported } from '@store/UI/UIActions';
+import { UIActionTypes } from '@store/UI/UITypes';
 import Styles from './SelectPostcardSize.styles';
 
 type SelectPostcardSizeScreenNavigationProp = StackNavigationProp<
@@ -31,6 +38,7 @@ interface Props {
   updateDraft: (draft: Draft) => void;
   draft: Draft;
   coins: number;
+  setTopbarRight: (details: TopbarRight | null) => void;
 }
 
 const SelectPostcardSizeBase = ({
@@ -39,6 +47,7 @@ const SelectPostcardSizeBase = ({
   updateDraft,
   draft,
   coins,
+  setTopbarRight,
 }: Props) => {
   const [selected, setSelected] = useState<PostcardSizeOption>(
     (draft as DraftPostcard).size
@@ -77,7 +86,7 @@ const SelectPostcardSizeBase = ({
 
   useFocusEffect(
     React.useCallback(() => {
-      setProfileOverride({
+      setTopbarRight({
         enabled: !!selected,
         text: i18n.t('Compose.selectBtn'),
         action: updatePostcardOption,
@@ -85,7 +94,7 @@ const SelectPostcardSizeBase = ({
       });
 
       return () => {
-        setProfileOverride(undefined);
+        setTopbarRight(null);
       };
     }, [])
   );
@@ -150,8 +159,12 @@ const mapStateToProps = (state: AppState) => ({
   coins: state.user.user.coins,
 });
 
-const mapDispatchToProps = (dispatch: Dispatch<MailActionTypes>) => ({
+const mapDispatchToProps = (
+  dispatch: Dispatch<MailActionTypes | UIActionTypes>
+) => ({
   updateDraft: (draft: Draft) => dispatch(setComposing(draft)),
+  setTopbarRight: (details: TopbarRight | null) =>
+    dispatch(setTopbarRightImported(details)),
 });
 
 const SelectPostcardSizeScreen = connect(

--- a/src/views/Onboarding/RegisterAddress.react.tsx
+++ b/src/views/Onboarding/RegisterAddress.react.tsx
@@ -62,8 +62,6 @@ class RegisterAddressScreen extends React.Component<Props, State> {
 
   private unsubscribeFocus: () => void;
 
-  private unsubscribeBlur: () => void;
-
   constructor(props: Props) {
     super(props);
     this.onNavigationFocus = this.onNavigationFocus.bind(this);
@@ -71,25 +69,16 @@ class RegisterAddressScreen extends React.Component<Props, State> {
       'focus',
       this.onNavigationFocus
     );
-    this.unsubscribeBlur = this.props.navigation.addListener(
-      'blur',
-      this.onNavigationBlur
-    );
   }
 
   componentWillUnmount(): void {
     this.unsubscribeFocus();
-    this.unsubscribeBlur();
   }
 
   onNavigationFocus(): void {
     if (this.address1.current) this.address1.current.forceFocus();
     this.updateValid();
   }
-
-  onNavigationBlur = (): void => {
-    setTopbarRight(null);
-  };
 
   updateValid = (): void => {
     if (

--- a/src/views/Onboarding/RegisterAddress.react.tsx
+++ b/src/views/Onboarding/RegisterAddress.react.tsx
@@ -6,7 +6,7 @@ import { Input, KeyboardAvoider, Picker, PickerRef } from '@components';
 import i18n from '@i18n';
 import { Typography } from '@styles';
 import { Validation, STATES_DROPDOWN } from '@utils';
-import { Image } from 'types';
+import { Image, TopbarRight } from 'types';
 import * as Segment from 'expo-analytics-segment';
 import { UserRegisterInfo } from '@store/User/UserTypes';
 import { register } from '@api';
@@ -15,7 +15,7 @@ import { NotifTypes } from '@store/Notif/NotifTypes';
 import { popupAlert } from '@components/Alert/Alert.react';
 import { dropdownError } from '@components/Dropdown/Dropdown.react';
 import COUNTRIES_FULL_TO_ABBREVS from '@utils/Countries';
-import { setProfileOverride } from '@components/Topbar';
+import { setTopbarRight } from '@store/UI/UIActions';
 import Styles from './Register.style';
 
 type RegisterAddressScreenNavigationProp = StackNavigationProp<
@@ -38,6 +38,7 @@ export interface Props {
       country: string;
     };
   };
+  setTopbarRight: (details: TopbarRight | null) => void;
 }
 
 export interface State {
@@ -87,7 +88,7 @@ class RegisterAddressScreen extends React.Component<Props, State> {
   }
 
   onNavigationBlur = (): void => {
-    setProfileOverride(undefined);
+    setTopbarRight(null);
   };
 
   updateValid = (): void => {
@@ -106,7 +107,7 @@ class RegisterAddressScreen extends React.Component<Props, State> {
           this.stateInput.current?.state.valid ||
           false) &&
         this.postal.current.state.valid;
-      setProfileOverride({
+      this.props.setTopbarRight({
         enabled: result,
         text: i18n.t('RegisterScreen.register'),
         action: this.doRegister,

--- a/src/views/Onboarding/RegisterCreds.react.tsx
+++ b/src/views/Onboarding/RegisterCreds.react.tsx
@@ -1,4 +1,4 @@
-import React, { createRef } from 'react';
+import React, { createRef, Dispatch } from 'react';
 import { ScrollView, Text, TouchableOpacity } from 'react-native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { AuthStackParamList, Screens } from '@utils/Screens';
@@ -9,8 +9,11 @@ import { Validation } from '@utils';
 import CheckedIcon from '@assets/views/Onboarding/Checked';
 import UncheckedIcon from '@assets/views/Onboarding/Unchecked';
 import { CheckBox } from 'react-native-elements';
-import { setProfileOverride } from '@components/Topbar';
 import * as Segment from 'expo-analytics-segment';
+import { TopbarRight } from 'types';
+import { connect } from 'react-redux';
+import { UIActionTypes } from '@store/UI/UITypes';
+import { setTopbarRight } from '@store/UI/UIActions';
 import Styles from './Register.style';
 
 type RegisterCredsScreenNavigationProp = StackNavigationProp<
@@ -23,6 +26,7 @@ export interface Props {
   route: {
     params: Record<string, unknown>;
   };
+  setTopbarRight: (details: TopbarRight | null) => void;
 }
 
 export interface State {
@@ -32,7 +36,7 @@ export interface State {
   remember: boolean;
 }
 
-class RegisterCredsScreen extends React.Component<Props, State> {
+class RegisterCredsScreenBase extends React.Component<Props, State> {
   private email = createRef<Input>();
 
   private password = createRef<Input>();
@@ -73,7 +77,7 @@ class RegisterCredsScreen extends React.Component<Props, State> {
   }
 
   onNavigationBlur = (): void => {
-    setProfileOverride(undefined);
+    this.props.setTopbarRight(null);
   };
 
   goForward = (): void => {
@@ -102,7 +106,7 @@ class RegisterCredsScreen extends React.Component<Props, State> {
         this.password.current.state.value ===
           this.passwordConfirmation.current.state.value;
       this.setState({ valid: result });
-      setProfileOverride({
+      this.props.setTopbarRight({
         enabled: result,
         text: i18n.t('RegisterScreen.next'),
         action: this.goForward,
@@ -250,5 +254,14 @@ class RegisterCredsScreen extends React.Component<Props, State> {
     );
   }
 }
+
+const mapDispatchToProps = (dispatch: Dispatch<UIActionTypes>) => ({
+  setTopbarRight: (details: TopbarRight | null) =>
+    dispatch(setTopbarRight(details)),
+});
+const RegisterCredsScreen = connect(
+  null,
+  mapDispatchToProps
+)(RegisterCredsScreenBase);
 
 export default RegisterCredsScreen;

--- a/src/views/Onboarding/RegisterCreds.react.tsx
+++ b/src/views/Onboarding/RegisterCreds.react.tsx
@@ -45,8 +45,6 @@ class RegisterCredsScreenBase extends React.Component<Props, State> {
 
   private unsubscribeFocus: () => void;
 
-  private unsubscribeBlur: () => void;
-
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -60,25 +58,16 @@ class RegisterCredsScreenBase extends React.Component<Props, State> {
       'focus',
       this.onNavigationFocus
     );
-    this.unsubscribeBlur = this.props.navigation.addListener(
-      'blur',
-      this.onNavigationBlur
-    );
   }
 
   componentWillUnmount(): void {
     this.unsubscribeFocus();
-    this.unsubscribeBlur();
   }
 
   onNavigationFocus(): void {
     if (this.email.current) this.email.current.forceFocus();
     this.updateValid();
   }
-
-  onNavigationBlur = (): void => {
-    this.props.setTopbarRight(null);
-  };
 
   goForward = (): void => {
     Segment.trackWithProperties('Signup - Clicks on Next', { step: 'Account' });

--- a/src/views/Onboarding/RegisterPersonal.react.tsx
+++ b/src/views/Onboarding/RegisterPersonal.react.tsx
@@ -57,8 +57,6 @@ class RegisterPersonalScreenBase extends React.Component<Props, State> {
 
   private unsubscribeFocus: () => void;
 
-  private unsubscribeBlur: () => void;
-
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -70,15 +68,10 @@ class RegisterPersonalScreenBase extends React.Component<Props, State> {
       'focus',
       this.onNavigationFocus
     );
-    this.unsubscribeBlur = this.props.navigation.addListener(
-      'blur',
-      this.onNavigationBlur
-    );
   }
 
   componentWillUnmount(): void {
     this.unsubscribeFocus();
-    this.unsubscribeBlur();
   }
 
   onNavigationFocus(): void {
@@ -87,10 +80,6 @@ class RegisterPersonalScreenBase extends React.Component<Props, State> {
       this.countryPicker.current.setStoredValue(COUNTRIES_FULL_TO_ABBREVS.US);
     this.updateValid();
   }
-
-  onNavigationBlur = (): void => {
-    this.props.setTopbarRight(null);
-  };
 
   goForward = (): void => {
     Segment.trackWithProperties('Signup - Clicks on Next', {

--- a/src/views/Onboarding/RegisterPersonal.react.tsx
+++ b/src/views/Onboarding/RegisterPersonal.react.tsx
@@ -1,4 +1,4 @@
-import React, { createRef } from 'react';
+import React, { createRef, Dispatch } from 'react';
 import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { AuthStackParamList, Screens } from '@utils/Screens';
@@ -12,11 +12,13 @@ import {
 import i18n from '@i18n';
 import { Typography } from '@styles';
 import { REFERRERS } from '@utils';
-import { Image } from 'types';
+import { Image, TopbarRight } from 'types';
 import { PicUploadTypes } from '@components/PicUpload/PicUpload.react';
-import { setProfileOverride } from '@components/Topbar';
 import * as Segment from 'expo-analytics-segment';
 import COUNTRIES_FULL_TO_ABBREVS from '@utils/Countries';
+import { UIActionTypes } from '@store/UI/UITypes';
+import { setTopbarRight } from '@store/UI/UIActions';
+import { connect } from 'react-redux';
 import Styles from './Register.style';
 
 type RegisterPersonalScreenNavigationProp = StackNavigationProp<
@@ -34,6 +36,7 @@ export interface Props {
       remember: boolean;
     };
   };
+  setTopbarRight: (details: TopbarRight | null) => void;
 }
 
 export interface State {
@@ -41,7 +44,7 @@ export interface State {
   image: Image | undefined;
 }
 
-class RegisterPersonalScreen extends React.Component<Props, State> {
+class RegisterPersonalScreenBase extends React.Component<Props, State> {
   private firstName = createRef<Input>();
 
   private lastName = createRef<Input>();
@@ -86,7 +89,7 @@ class RegisterPersonalScreen extends React.Component<Props, State> {
   }
 
   onNavigationBlur = (): void => {
-    setProfileOverride(undefined);
+    this.props.setTopbarRight(null);
   };
 
   goForward = (): void => {
@@ -122,7 +125,7 @@ class RegisterPersonalScreen extends React.Component<Props, State> {
         this.referrerPicker.current.isValueSelected() &&
         this.countryPicker.current.isValueSelected();
       this.setState({ valid: result });
-      setProfileOverride({
+      this.props.setTopbarRight({
         enabled: result,
         text: i18n.t('RegisterScreen.next'),
         action: this.goForward,
@@ -239,5 +242,14 @@ class RegisterPersonalScreen extends React.Component<Props, State> {
     );
   }
 }
+
+const mapDispatchToProps = (dispatch: Dispatch<UIActionTypes>) => ({
+  setTopbarRight: (details: TopbarRight | null) =>
+    dispatch(setTopbarRight(details)),
+});
+const RegisterPersonalScreen = connect(
+  null,
+  mapDispatchToProps
+)(RegisterPersonalScreenBase);
 
 export default RegisterPersonalScreen;

--- a/src/views/Report/IssuesDetail.react.tsx
+++ b/src/views/Report/IssuesDetail.react.tsx
@@ -72,12 +72,7 @@ function mapIssueToDetailsPrimaryCTA(props: Props, type: DeliveryReportTypes) {
       );
     case DeliveryReportTypes.unsure:
       return defaultCTAButton(
-        () => {
-          props.navigation.reset({
-            index: 0,
-            routes: [{ name: Screens.ContactSelector }],
-          });
-        },
+        () => null,
         i18n.t('IssuesDetailScreen.returnHome'),
         ReportStyles.buttonText,
         ReportStyles.buttonReverse
@@ -104,12 +99,7 @@ function mapIssueToDetailsSecondaryCTA(
   switch (type) {
     case DeliveryReportTypes.received:
       return defaultCTAButton(
-        () => {
-          props.navigation.reset({
-            index: 0,
-            routes: [{ name: Screens.ContactSelector }],
-          });
-        },
+        () => null,
         i18n.t('IssuesDetailScreen.returnHome'),
         ReportStyles.buttonText,
         ReportStyles.buttonReverse

--- a/src/views/Report/IssuesDetailSecondary.react.tsx
+++ b/src/views/Report/IssuesDetailSecondary.react.tsx
@@ -88,12 +88,7 @@ function mapIssueToDetailsPrimaryCTA(props: Props, type: DeliveryReportTypes) {
   switch (type) {
     case DeliveryReportTypes.haveNotAsked:
       return defaultCTAButton(
-        () => {
-          props.navigation.reset({
-            index: 0,
-            routes: [{ name: Screens.ContactSelector }],
-          });
-        },
+        () => null,
         i18n.t('IssuesDetailScreen.returnHome'),
         ReportStyles.buttonText,
         ReportStyles.buttonReverse
@@ -140,12 +135,7 @@ function mapIssueToDetailsSecondaryCTA(
     case DeliveryReportTypes.haveNotReceived:
       if (props.contact.facility && props.contact.facility.phone) {
         return defaultCTAButton(
-          () => {
-            props.navigation.reset({
-              index: 0,
-              routes: [{ name: Screens.ContactSelector }],
-            });
-          },
+          () => null,
           i18n.t('IssuesDetailScreen.IllWait'),
           ReportStyles.buttonText,
           ReportStyles.buttonReverse

--- a/src/views/Report/SupportFAQDetail.react.tsx
+++ b/src/views/Report/SupportFAQDetail.react.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import { Text, View, Linking } from 'react-native';
 import { Typography } from '@styles';
 import { Button } from '@components';
-import { AppStackParamList, Screens } from '@utils/Screens';
+import { AppStackParamList, Screens, Tabs } from '@utils/Screens';
 import { StackNavigationProp } from '@react-navigation/stack';
 import i18n from '@i18n';
 import { SupportFAQTypes } from 'types';
 import Emoji from 'react-native-emoji';
+import { navigate } from '@utils';
 import Styles from './SupportFAQ.styles';
 
 type SupportFAQDetailScreenNavigationProp = StackNavigationProp<

--- a/src/views/Store/SelectRecipient.react.tsx
+++ b/src/views/Store/SelectRecipient.react.tsx
@@ -1,9 +1,8 @@
 import { ContactSelectorCard } from '@components';
-import { setProfileOverride } from '@components/Topbar';
 import i18n from '@i18n';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { AppState } from '@store/types';
-import { Contact, MailTypes, PremadeDesign } from 'types';
+import { Contact, MailTypes, PremadeDesign, TopbarRight } from 'types';
 import { AppStackParamList, Screens } from '@utils/Screens';
 import React, { Dispatch, useEffect, useState } from 'react';
 import { View, Text, Linking, Image as ImageComponent } from 'react-native';
@@ -16,6 +15,8 @@ import { Typography } from '@styles';
 import { UserActionTypes } from '@store/User/UserTypes';
 import { deductPremiumCoins } from '@store/User/UserActions';
 import Loading from '@assets/common/loading.gif';
+import { setTopbarRight as setTopbarRightImported } from '@store/UI/UIActions';
+import { UIActionTypes } from '@store/UI/UITypes';
 
 type SelectPostcardSizeScreenNavigationProp = StackNavigationProp<
   AppStackParamList,
@@ -27,6 +28,7 @@ interface Props {
   navigation: SelectPostcardSizeScreenNavigationProp;
   route: { params: { item: PremadeDesign } };
   deduct: (coins: number) => void;
+  setTopbarRight: (details: TopbarRight | null) => void;
 }
 
 const SelectRecipientBase = ({
@@ -34,6 +36,7 @@ const SelectRecipientBase = ({
   navigation,
   route,
   deduct,
+  setTopbarRight,
 }: Props) => {
   const [recipient, setRecipient] = useState<Contact>();
   const [processingPurchase, setProcessingPurchase] = useState(false);
@@ -42,7 +45,7 @@ const SelectRecipientBase = ({
     const { item } = route.params;
     if (!recipient) return;
     setProcessingPurchase(true);
-    setProfileOverride(undefined);
+    setTopbarRight(null);
     popupAlert({
       title: i18n.t('SelectRecipient.modalHeader'),
       message: i18n.t('SelectRecipient.modalMessage'),
@@ -68,7 +71,7 @@ const SelectRecipientBase = ({
                 routes: [{ name: Screens.StoreItemPurchaseSuccess }],
               });
             } catch (err) {
-              setProfileOverride({
+              setTopbarRight({
                 enabled: !!recipient,
                 text: i18n.t('Compose.selectBtn'),
                 action: confirmPurchase,
@@ -103,7 +106,7 @@ const SelectRecipientBase = ({
   };
 
   useEffect(() => {
-    setProfileOverride({
+    setTopbarRight({
       enabled: !!recipient,
       text: i18n.t('Compose.selectBtn'),
       action: confirmPurchase,
@@ -111,7 +114,7 @@ const SelectRecipientBase = ({
     });
 
     return () => {
-      setProfileOverride(undefined);
+      setTopbarRight(null);
     };
   }, [recipient]);
 
@@ -138,19 +141,6 @@ const SelectRecipientBase = ({
       />
     );
   };
-
-  const emptyLoading = (
-    <View
-      style={{
-        flex: 1,
-        height: 300,
-        justifyContent: 'center',
-        alignItems: 'center',
-      }}
-    >
-      <ImageComponent style={{ width: 40, height: 40 }} source={Loading} />
-    </View>
-  );
 
   if (processingPurchase)
     return (
@@ -190,11 +180,13 @@ const mapStateToProps = (state: AppState) => ({
   contacts: state.contact.existing,
 });
 
-const mapDispatchToProps = (dispatch: Dispatch<UserActionTypes>) => {
-  return {
-    deduct: (coins: number) => dispatch(deductPremiumCoins(coins)),
-  };
-};
+const mapDispatchToProps = (
+  dispatch: Dispatch<UserActionTypes | UIActionTypes>
+) => ({
+  deduct: (coins: number) => dispatch(deductPremiumCoins(coins)),
+  setTopbarRight: (details: TopbarRight | null) =>
+    dispatch(setTopbarRightImported(details)),
+});
 
 const SelectRecipientScreen = connect(
   mapStateToProps,

--- a/src/views/Store/SelectRecipient.react.tsx
+++ b/src/views/Store/SelectRecipient.react.tsx
@@ -112,10 +112,6 @@ const SelectRecipientBase = ({
       action: confirmPurchase,
       blocking: true,
     });
-
-    return () => {
-      setTopbarRight(null);
-    };
   }, [recipient]);
 
   const renderItem = ({

--- a/src/views/Update/UpdateContact.react.tsx
+++ b/src/views/Update/UpdateContact.react.tsx
@@ -72,8 +72,6 @@ class UpdateContactScreenBase extends React.Component<Props, State> {
 
   private unsubscribeFocus: () => void;
 
-  private unsubscribeBlur: () => void;
-
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -86,16 +84,10 @@ class UpdateContactScreenBase extends React.Component<Props, State> {
     this.doDeleteContact = this.doDeleteContact.bind(this);
     this.doUpdateContact = this.doUpdateContact.bind(this);
     this.onNavigationFocus = this.onNavigationFocus.bind(this);
-    this.onNavigationBlur = this.onNavigationBlur.bind(this);
 
     this.unsubscribeFocus = this.props.navigation.addListener(
       'focus',
       this.onNavigationFocus
-    );
-
-    this.unsubscribeBlur = this.props.navigation.addListener(
-      'blur',
-      this.onNavigationBlur
     );
   }
 
@@ -105,7 +97,6 @@ class UpdateContactScreenBase extends React.Component<Props, State> {
 
   componentWillUnmount() {
     this.unsubscribeFocus();
-    this.unsubscribeBlur();
   }
 
   onNavigationFocus() {
@@ -117,10 +108,6 @@ class UpdateContactScreenBase extends React.Component<Props, State> {
       blocking: true,
     });
   }
-
-  onNavigationBlur = () => {
-    this.props.setTopbarRight(null);
-  };
 
   setValid(val: boolean) {
     this.props.setTopbarRight({

--- a/src/views/Update/UpdateContact.react.tsx
+++ b/src/views/Update/UpdateContact.react.tsx
@@ -14,12 +14,11 @@ import {
   Picker,
   PickerRef,
 } from '@components';
-import { setProfileOverride } from '@components/Topbar';
 import { AppStackParamList } from '@utils/Screens';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { connect } from 'react-redux';
 import { AppState } from '@store/types';
-import { Facility, Image, Contact } from 'types';
+import { Facility, Image, Contact, TopbarRight } from 'types';
 import { Typography, Colors } from '@styles';
 import { dropdownError } from '@components/Dropdown/Dropdown.react';
 import { updateContact, deleteContact } from '@api';
@@ -39,6 +38,7 @@ type UpdateContactScreenNavigationProp = StackNavigationProp<
 export interface Props {
   navigation: UpdateContactScreenNavigationProp;
   contact: Contact;
+  setTopbarRight: (details: TopbarRight | null) => void;
 }
 
 export interface State {
@@ -108,7 +108,7 @@ class UpdateContactScreenBase extends React.Component<Props, State> {
 
   onNavigationFocus() {
     this.loadValuesFromStore();
-    setProfileOverride({
+    this.props.setTopbarRight({
       enabled: true,
       text: i18n.t('UpdateContactScreen.save'),
       action: this.doUpdateContact,
@@ -117,11 +117,11 @@ class UpdateContactScreenBase extends React.Component<Props, State> {
   }
 
   onNavigationBlur = () => {
-    setProfileOverride(undefined);
+    this.props.setTopbarRight(null);
   };
 
   setValid(val: boolean) {
-    setProfileOverride({
+    this.props.setTopbarRight({
       enabled: val,
       text: i18n.t('UpdateContactScreen.save'),
       action: this.doUpdateContact,
@@ -461,11 +461,9 @@ class UpdateContactScreenBase extends React.Component<Props, State> {
   }
 }
 
-const mapStateToProps = (state: AppState) => {
-  return {
-    contact: state.contact.active,
-  };
-};
+const mapStateToProps = (state: AppState) => ({
+  contact: state.contact.active,
+});
 
 const UpdateContactScreen = connect(mapStateToProps)(UpdateContactScreenBase);
 

--- a/src/views/Update/UpdateContact.react.tsx
+++ b/src/views/Update/UpdateContact.react.tsx
@@ -1,4 +1,4 @@
-import React, { createRef } from 'react';
+import React, { createRef, Dispatch } from 'react';
 import {
   Text,
   Keyboard,
@@ -28,6 +28,8 @@ import { PicUploadTypes } from '@components/PicUpload/PicUpload.react';
 import { popupAlert } from '@components/Alert/Alert.react';
 import { Validation, STATES_DROPDOWN } from '@utils';
 import * as Segment from 'expo-analytics-segment';
+import { UIActionTypes } from '@store/UI/UITypes';
+import { setTopbarRight } from '@store/UI/UIActions';
 import Styles from './UpdateContact.styles';
 
 type UpdateContactScreenNavigationProp = StackNavigationProp<
@@ -464,7 +466,13 @@ class UpdateContactScreenBase extends React.Component<Props, State> {
 const mapStateToProps = (state: AppState) => ({
   contact: state.contact.active,
 });
-
-const UpdateContactScreen = connect(mapStateToProps)(UpdateContactScreenBase);
+const mapDispatchToProps = (dispatch: Dispatch<UIActionTypes>) => ({
+  setTopbarRight: (details: TopbarRight | null) =>
+    dispatch(setTopbarRight(details)),
+});
+const UpdateContactScreen = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(UpdateContactScreenBase);
 
 export default UpdateContactScreen;

--- a/src/views/Update/UpdateProfile.react.tsx
+++ b/src/views/Update/UpdateProfile.react.tsx
@@ -64,8 +64,6 @@ class UpdateProfileScreenBase extends React.Component<Props, State> {
 
   private unsubscribeFocus: () => void;
 
-  private unsubscribeBlur: () => void;
-
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -76,14 +74,9 @@ class UpdateProfileScreenBase extends React.Component<Props, State> {
     this.updateValid = this.updateValid.bind(this);
     this.doUpdateProfile = this.doUpdateProfile.bind(this);
     this.onNavigationFocus = this.onNavigationFocus.bind(this);
-    this.onNavigationBlur = this.onNavigationBlur.bind(this);
     this.unsubscribeFocus = this.props.navigation.addListener(
       'focus',
       this.onNavigationFocus
-    );
-    this.unsubscribeBlur = this.props.navigation.addListener(
-      'blur',
-      this.onNavigationBlur
     );
   }
 
@@ -93,7 +86,6 @@ class UpdateProfileScreenBase extends React.Component<Props, State> {
 
   componentWillUnmount() {
     this.unsubscribeFocus();
-    this.unsubscribeBlur();
   }
 
   onNavigationFocus() {
@@ -105,10 +97,6 @@ class UpdateProfileScreenBase extends React.Component<Props, State> {
       blocking: true,
     });
   }
-
-  onNavigationBlur = () => {
-    this.props.setTopbarRight(null);
-  };
 
   setValid(val: boolean) {
     this.props.setTopbarRight({

--- a/src/views/Update/UpdateProfile.react.tsx
+++ b/src/views/Update/UpdateProfile.react.tsx
@@ -1,4 +1,4 @@
-import React, { createRef } from 'react';
+import React, { createRef, Dispatch } from 'react';
 import {
   Text,
   Keyboard,
@@ -14,13 +14,12 @@ import {
   Picker,
   PickerRef,
 } from '@components';
-import { setProfileOverride } from '@components/Topbar';
 import { AppStackParamList, Screens } from '@utils/Screens';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { connect } from 'react-redux';
 import { AppState } from '@store/types';
 import { UserState, User } from '@store/User/UserTypes';
-import { Image } from 'types';
+import { Image, TopbarRight } from 'types';
 import { Colors, Typography } from '@styles';
 import { dropdownError } from '@components/Dropdown/Dropdown.react';
 import { logout, updateProfile } from '@api';
@@ -29,6 +28,8 @@ import { PicUploadTypes } from '@components/PicUpload/PicUpload.react';
 import { format } from 'date-fns';
 import { STATES_DROPDOWN, Validation } from '@utils';
 import * as Segment from 'expo-analytics-segment';
+import { UIActionTypes } from '@store/UI/UITypes';
+import { setTopbarRight } from '@store/UI/UIActions';
 import Styles from './UpdateProfile.styles';
 
 type UpdateProfileScreenNavigationProp = StackNavigationProp<
@@ -39,6 +40,7 @@ type UpdateProfileScreenNavigationProp = StackNavigationProp<
 export interface Props {
   navigation: UpdateProfileScreenNavigationProp;
   userState: UserState;
+  setTopbarRight: (details: TopbarRight | null) => void;
 }
 
 export interface State {
@@ -96,7 +98,7 @@ class UpdateProfileScreenBase extends React.Component<Props, State> {
 
   onNavigationFocus() {
     this.loadValuesFromStore();
-    setProfileOverride({
+    this.props.setTopbarRight({
       enabled: true,
       text: i18n.t('UpdateProfileScreen.save'),
       action: this.doUpdateProfile,
@@ -105,11 +107,11 @@ class UpdateProfileScreenBase extends React.Component<Props, State> {
   }
 
   onNavigationBlur = () => {
-    setProfileOverride(undefined);
+    this.props.setTopbarRight(null);
   };
 
   setValid(val: boolean) {
-    setProfileOverride({
+    this.props.setTopbarRight({
       enabled: val,
       text: i18n.t('UpdateProfileScreen.save'),
       action: this.doUpdateProfile,
@@ -349,12 +351,16 @@ class UpdateProfileScreenBase extends React.Component<Props, State> {
   }
 }
 
-const mapStateToProps = (state: AppState) => {
-  return {
-    userState: state.user,
-  };
-};
-
-const UpdateProfileScreen = connect(mapStateToProps)(UpdateProfileScreenBase);
+const mapStateToProps = (state: AppState) => ({
+  userState: state.user,
+});
+const mapDispatchToProps = (dispatch: Dispatch<UIActionTypes>) => ({
+  setTopbarRight: (details: TopbarRight | null) =>
+    dispatch(setTopbarRight(details)),
+});
+const UpdateProfileScreen = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(UpdateProfileScreenBase);
 
 export default UpdateProfileScreen;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Use state instead of refs for the top bar. Move the profile screen from topbar to tab.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #399 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
