### PR TITLE
[Tabs] Fix explore modal navigation.

### DIFF
--- a/src/navigations/TabIcon.react.tsx
+++ b/src/navigations/TabIcon.react.tsx
@@ -1,33 +1,24 @@
 import { Icon } from '@components';
-import { Colors, Typography } from '@styles';
+import { Tabs } from '@utils/Screens';
 import React from 'react';
-import { GestureResponderEvent, Text, TouchableOpacity } from 'react-native';
+import ActiveHome from '@assets/navigation/ActiveHome';
+import ActiveStore from '@assets/navigation/ActiveStore';
+import Home from '@assets/navigation/Home';
+import Store from '@assets/navigation/Store';
 
 interface Props {
   name: string;
-  svg: string;
-  onPress: (e: GestureResponderEvent) => void;
   active: boolean;
 }
 
-const TabIcon: React.FC<Props> = ({ name, svg, onPress, active }: Props) => {
-  return (
-    <TouchableOpacity
-      activeOpacity={0.9}
-      style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}
-      onPress={onPress}
-    >
-      <Icon svg={svg} />
-      <Text
-        style={[
-          active ? Typography.FONT_SEMIBOLD : Typography.FONT_REGULAR,
-          { color: active ? Colors.AMEELIO_BLACK : Colors.GRAY_400 },
-        ]}
-      >
-        {name}
-      </Text>
-    </TouchableOpacity>
-  );
+const TabIcon: React.FC<Props> = ({ name, active }: Props) => {
+  let icon: string;
+  if (name === Tabs.Store) {
+    icon = active ? ActiveStore : Store;
+  } else {
+    icon = active ? ActiveHome : Home;
+  }
+  return <Icon svg={icon} />;
 };
 
 export default TabIcon;

--- a/src/navigations/index.tsx
+++ b/src/navigations/index.tsx
@@ -5,12 +5,6 @@ import { AuthInfo, UserState } from '@store/User/UserTypes';
 import { navigationRef, navigate } from '@utils';
 import { setProfile } from '@components/Topbar';
 import { NavigationContainer } from '@react-navigation/native';
-import HomeIcon from '@assets/navigation/Home';
-import StoreIcon from '@assets/navigation/Store';
-import ActiveStoreIcon from '@assets/navigation/ActiveStore';
-import ActiveHomeIcon from '@assets/navigation/ActiveHome';
-
-import i18n from '@i18n';
 import {
   Screens,
   AuthStackParamList,
@@ -19,9 +13,10 @@ import {
   Tabs,
 } from '@utils/Screens';
 import { SplashScreen } from '@views';
-import { GestureResponderEvent } from 'react-native';
-import { RootTab } from './Navigators';
+import { Text } from 'react-native';
+import { Colors, Typography } from '@styles';
 
+import { RootTab } from './Navigators';
 import Auth from './Auth';
 import Home from './Home';
 import Store from './Store';
@@ -38,9 +33,7 @@ export interface Props {
 
 const NavigatorBase: React.FC<Props> = (props: Props) => {
   const [tabsVisible, setTabsVisible] = useState(true);
-  const [active, setActive] = useState(Tabs.Home);
 
-  // Determine which views should be accessible
   let screens;
   if (
     props.authInfo.isLoadingToken ||
@@ -52,48 +45,8 @@ const NavigatorBase: React.FC<Props> = (props: Props) => {
   } else {
     screens = (
       <>
-        <RootTab.Screen
-          name={Tabs.Home}
-          component={Home}
-          options={{
-            tabBarButton: (tabProps) => {
-              return (
-                <TabIcon
-                  name={i18n.t('Navigation.home')}
-                  svg={active === Tabs.Home ? ActiveHomeIcon : HomeIcon}
-                  active={Tabs.Home === active}
-                  onPress={(e: GestureResponderEvent) => {
-                    if (tabProps.onPress) {
-                      tabProps.onPress(e);
-                    }
-                    setActive(Tabs.Home);
-                  }}
-                />
-              );
-            },
-          }}
-        />
-        <RootTab.Screen
-          name={Tabs.Store}
-          component={Store}
-          options={{
-            tabBarButton: (tabProps) => {
-              return (
-                <TabIcon
-                  name={i18n.t('Navigation.store')}
-                  svg={active === Tabs.Store ? ActiveStoreIcon : StoreIcon}
-                  active={Tabs.Store === active}
-                  onPress={(e: GestureResponderEvent) => {
-                    if (tabProps.onPress) {
-                      tabProps.onPress(e);
-                    }
-                    setActive(Tabs.Store);
-                  }}
-                />
-              );
-            },
-          }}
-        />
+        <RootTab.Screen name={Tabs.Home} component={Home} />
+        <RootTab.Screen name={Tabs.Store} component={Store} />
       </>
     );
   }
@@ -124,9 +77,29 @@ const NavigatorBase: React.FC<Props> = (props: Props) => {
             route.name !== Tabs.Splash &&
             tabsVisible,
           tabBarVisibilityAnimationConfig: {},
+          tabBarIcon: ({ focused }: { focused: boolean }) => {
+            return <TabIcon name={route.name} active={focused} />;
+          },
+          tabBarLabel: ({ focused }: { focused: boolean }) => {
+            return (
+              <Text
+                style={[
+                  focused ? Typography.FONT_SEMIBOLD : Typography.FONT_REGULAR,
+                  {
+                    color: focused ? Colors.AMEELIO_BLACK : Colors.GRAY_400,
+                    bottom: 4,
+                  },
+                ]}
+              >
+                {route.name}
+              </Text>
+            );
+          },
         })}
         tabBarOptions={{
-          style: { height: 64 },
+          style: {
+            height: 64,
+          },
           keyboardHidesTabBar: true,
         }}
       >

--- a/src/views/Home/ContactSelector.react.tsx
+++ b/src/views/Home/ContactSelector.react.tsx
@@ -1,7 +1,7 @@
 import React, { Dispatch } from 'react';
 import { Text, FlatList, View } from 'react-native';
 import { Button, Icon, KeyboardAvoider } from '@components';
-import { AppStackParamList, Screens } from '@utils/Screens';
+import { AppStackParamList, Screens, Tabs } from '@utils/Screens';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { Colors, Typography } from '@styles';
 import { AppState } from '@store/types';
@@ -91,6 +91,20 @@ class ContactSelectorScreenBase extends React.Component<Props> {
       this.props.setUnrespondedNotifs([]);
       this.props.navigation.navigate(Screens.Issues);
     }
+  }
+
+  componentWillUnmount() {
+    this.unsubscribeFocus();
+  }
+
+  async onNavigationFocus() {
+    if (this.props.existingContacts.length === 0) {
+      this.props.navigation.replace(Screens.IntroContact);
+    }
+
+    getCategories().catch(() => {
+      dropdownError({ message: i18n.t('Error.cantRefreshCategories') });
+    });
 
     if (!this.props.hasShownPrompt) {
       popupAlert({
@@ -108,7 +122,7 @@ class ContactSelectorScreenBase extends React.Component<Props> {
         buttons: [
           {
             text: i18n.t('Alert.exploreStoreNow'),
-            onPress: () => this.props.navigation.navigate('Store'),
+            onPress: () => this.props.navigation.navigate(Tabs.Store),
           },
           {
             text: i18n.t('Alert.noThanks'),
@@ -119,19 +133,6 @@ class ContactSelectorScreenBase extends React.Component<Props> {
       });
       this.props.setShownPrompt(true);
     }
-  }
-
-  componentWillUnmount() {
-    this.unsubscribeFocus();
-  }
-
-  async onNavigationFocus() {
-    if (this.props.existingContacts.length === 0) {
-      this.props.navigation.replace(Screens.IntroContact);
-    }
-    getCategories().catch(() => {
-      dropdownError({ message: i18n.t('Error.cantRefreshCategories') });
-    });
   }
 
   renderItem = ({ item }: { item: Contact; index: number }): JSX.Element => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Tweaked navigation from the explore modal to work. Tweaked the way we do tab bar buttons and labels to update on navigation that is triggered programmatically and not from clicking on the tab.

## Description
<!--- Describe your changes in detail -->
Use the tabBarIcon and tabBarLabel componets instead of tabBarButton. Use enum to navigate instead of raw string.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #433 
